### PR TITLE
Fixed bug where different parsers represent offense datetime differently

### DIFF
--- a/dear_petition/petition/models.py
+++ b/dear_petition/petition/models.py
@@ -155,7 +155,7 @@ class Batch(models.Model):
     @property
     def most_recent_record(self):
         most_recent_record = None
-        most_recent_offense_date = datetime(1900, 1, 1)
+        most_recent_offense_date = datetime.min
         for record in self.records.order_by("pk"):
             if not record.offense_date:
                 continue


### PR DESCRIPTION
500 error was happening because the most recent record compares dates by stripping the datetime, but it was chugging because some data in that field is represented as datetime, while others are represented as just dates, depending on which parser it came from. I prefer this change rather than modifying the most_recent_record function because I think it will make it easier to code in the future if we keep our data formats consistent.