### PR TITLE
[DP 34/map petitioner] 

### DIFF
--- a/dear_petition/petition/conftest.py
+++ b/dear_petition/petition/conftest.py
@@ -11,6 +11,11 @@ from dear_petition.petition.tests.factories import (
 
 
 @pytest.fixture
+def data():
+    return {}
+
+
+@pytest.fixture
 def batch(user):
     yield BatchFactory(user=user)
 

--- a/dear_petition/petition/export/mapper.py
+++ b/dear_petition/petition/export/mapper.py
@@ -31,12 +31,16 @@ def map_petition(data, petition, extra={}):
 
 def map_petitioner(data, petition, extra={}):
     record = petition.batch.most_recent_record
-    data["NamePetitioner"] = record.label  # load.py line 28 (label is set to name attr)
-    data["Race"] = record.race
-    data["Sex"] = record.sex
-    data["DOB"] = record.dob.strftime(constants.DATE_FORMAT)
-    # data["Age"] = record.age
-    data["ConsJdgmntFileNum"] = record.file_no
+    data["NamePetitioner"] = getattr(
+        record, "label", None
+    )  # load.py line 28 (label is set to name attr)
+    data["Race"] = getattr(record, "race", None)
+    data["Sex"] = getattr(record, "sex", None)
+    dob = getattr(record, "dob", None)
+    if dob:
+        data["DOB"] = dob.strftime(constants.DATE_FORMAT)
+    # data["Age"] = getattr(record, "age", None)
+    data["ConsJdgmntFileNum"] = getattr(record, "file_no", None)
 
 
 def map_attorney(data, petition, extra={}):

--- a/dear_petition/petition/export/mapper.py
+++ b/dear_petition/petition/export/mapper.py
@@ -30,7 +30,13 @@ def map_petition(data, petition, extra={}):
 
 
 def map_petitioner(data, petition, extra={}):
-    pass
+    record = petition.batch.most_recent_record
+    data["NamePetitioner"] = record.label  # load.py line 28 (label is set to name attr)
+    data["Race"] = record.race
+    data["Sex"] = record.sex
+    data["DOB"] = record.dob.strftime(constants.DATE_FORMAT)
+    # data["Age"] = record.age
+    data["ConsJdgmntFileNum"] = record.file_no
 
 
 def map_attorney(data, petition, extra={}):

--- a/dear_petition/petition/export/tests/test_mapper.py
+++ b/dear_petition/petition/export/tests/test_mapper.py
@@ -2,11 +2,17 @@ import pytest
 
 from dear_petition.petition import constants
 from dear_petition.petition.export import mapper
+from dear_petition.petition.utils import make_datetime_aware
+
+from dear_petition.petition.tests.factories import (
+    BatchFactory,
+    CIPRSRecordFactory,
+)
 
 
 pytestmark = pytest.mark.django_db
 
-
+# map_petition test
 @pytest.mark.parametrize("county", ["DURHAM", "WAKE"])
 def test_map_petition__county(petition, county):
     data = {}
@@ -29,3 +35,66 @@ def test_map_petition__district(petition):
     mapper.map_petition(data, petition)
     assert data["District"] == "Yes"
     assert data["Superior"] == ""
+
+
+# map_petitioner tests
+def test_map_petitioner__name(petition):
+    data = {}
+    batch = BatchFactory()
+    record = CIPRSRecordFactory(batch=batch)
+    record.refresh_record_from_data()
+    petition.batch = batch
+    mapper.map_petitioner(data, petition)
+    assert data["NamePetitioner"] == record.label
+
+
+def test_map_petitioner__race(petition):
+    data = {}
+    batch = BatchFactory()
+    record = CIPRSRecordFactory(batch=batch)
+    record.refresh_record_from_data()
+    petition.batch = batch
+    mapper.map_petitioner(data, petition)
+    assert data["Race"] == record.race
+
+
+def test_map_petitioner__sex(petition):
+    data = {}
+    batch = BatchFactory()
+    record = CIPRSRecordFactory(batch=batch)
+    record.refresh_record_from_data()
+    petition.batch = batch
+    mapper.map_petitioner(data, petition)
+    assert data["Sex"] == record.sex
+
+
+def test_map_petitioner__dob(petition):
+    data = {}
+    batch = BatchFactory()
+    record = CIPRSRecordFactory(batch=batch)
+    record.refresh_record_from_data()
+    petition.batch = batch
+    mapper.map_petitioner(data, petition)
+    assert data["DOB"] == make_datetime_aware(record.dob).date().strftime(
+        constants.DATE_FORMAT
+    )
+
+
+# def test_map_petitioner__age(petition):
+#     data = {}
+#     batch = BatchFactory()
+#     record = CIPRSRecordFactory(batch=batch)
+#     record.refresh_record_from_data()
+#     petition.batch = batch
+#     mapper.map_petitioner(data, petition)
+#     assert data["Age"] == record.age
+
+
+def test_map_petitioner__file_no(petition):
+    data = {}
+    batch = BatchFactory()
+    record = CIPRSRecordFactory(batch=batch)
+    record.refresh_record_from_data()
+    petition.batch = batch
+    mapper.map_petitioner(data, petition)
+    assert data["ConsJdgmntFileNum"] == record.file_no

--- a/dear_petition/petition/export/tests/test_mapper.py
+++ b/dear_petition/petition/export/tests/test_mapper.py
@@ -14,23 +14,20 @@ pytestmark = pytest.mark.django_db
 
 # map_petition test
 @pytest.mark.parametrize("county", ["DURHAM", "WAKE"])
-def test_map_petition__county(petition, county):
-    data = {}
+def test_map_petition__county(data, petition, county):
     petition.county = county
     mapper.map_petition(data, petition)
     assert data["County"] == county
 
 
-def test_map_petition__superior(petition):
-    data = {}
+def test_map_petition__superior(data, petition):
     petition.jurisdiction = constants.SUPERIOR_COURT
     mapper.map_petition(data, petition)
     assert data["District"] == ""
     assert data["Superior"] == "Yes"
 
 
-def test_map_petition__district(petition):
-    data = {}
+def test_map_petition__district(data, petition):
     petition.jurisdiction = constants.DISTRICT_COURT
     mapper.map_petition(data, petition)
     assert data["District"] == "Yes"
@@ -38,63 +35,35 @@ def test_map_petition__district(petition):
 
 
 # map_petitioner tests
-def test_map_petitioner__name(petition):
-    data = {}
-    batch = BatchFactory()
-    record = CIPRSRecordFactory(batch=batch)
-    record.refresh_record_from_data()
-    petition.batch = batch
+def test_map_petitioner__name(data, petition, record1):
     mapper.map_petitioner(data, petition)
-    assert data["NamePetitioner"] == record.label
+    assert data["NamePetitioner"] == record1.label
 
 
-def test_map_petitioner__race(petition):
-    data = {}
-    batch = BatchFactory()
-    record = CIPRSRecordFactory(batch=batch)
-    record.refresh_record_from_data()
-    petition.batch = batch
+def test_map_petitioner__race(data, petition, record1):
     mapper.map_petitioner(data, petition)
-    assert data["Race"] == record.race
+    assert data["Race"] == record1.race
 
 
-def test_map_petitioner__sex(petition):
-    data = {}
-    batch = BatchFactory()
-    record = CIPRSRecordFactory(batch=batch)
-    record.refresh_record_from_data()
-    petition.batch = batch
+def test_map_petitioner__sex(data, petition, record1):
     mapper.map_petitioner(data, petition)
-    assert data["Sex"] == record.sex
+    assert data["Sex"] == record1.sex
 
 
-def test_map_petitioner__dob(petition):
-    data = {}
-    batch = BatchFactory()
-    record = CIPRSRecordFactory(batch=batch)
-    record.refresh_record_from_data()
-    petition.batch = batch
+def test_map_petitioner__dob(data, petition, record1):
+    record1.dob = "2020-01-01"
+    record1.save()
     mapper.map_petitioner(data, petition)
-    assert data["DOB"] == make_datetime_aware(record.dob).date().strftime(
+    assert data["DOB"] == make_datetime_aware(record1.dob).date().strftime(
         constants.DATE_FORMAT
     )
 
 
-# def test_map_petitioner__age(petition):
-#     data = {}
-#     batch = BatchFactory()
-#     record = CIPRSRecordFactory(batch=batch)
-#     record.refresh_record_from_data()
-#     petition.batch = batch
+# def test_map_petitioner__age(data, petition, record1):
 #     mapper.map_petitioner(data, petition)
-#     assert data["Age"] == record.age
+#     assert data["Age"] == record1.age
 
 
-def test_map_petitioner__file_no(petition):
-    data = {}
-    batch = BatchFactory()
-    record = CIPRSRecordFactory(batch=batch)
-    record.refresh_record_from_data()
-    petition.batch = batch
+def test_map_petitioner__file_no(data, petition, record1):
     mapper.map_petitioner(data, petition)
-    assert data["ConsJdgmntFileNum"] == record.file_no
+    assert data["ConsJdgmntFileNum"] == record1.file_no


### PR DESCRIPTION
This PR further refactors what was `data_dict.py`. This PR takes code related to the petitioner and puts it in the `map_petitioner` definition. Note: age is commented out in map_petitioner and the associated `AGE` test is commented out. Once we store `age` as field on the CIPRSRecord we should uncomment these lines.

https://caktus.atlassian.net/browse/DP-34