### PR TITLE
Add Django views for password reset

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -114,7 +114,7 @@ AUTH_USER_MODEL = "users.User"
 # https://docs.djangoproject.com/en/dev/ref/settings/#login-redirect-url
 LOGIN_REDIRECT_URL = "users:redirect"
 # https://docs.djangoproject.com/en/dev/ref/settings/#login-url
-LOGIN_URL = "account_login"
+LOGIN_URL = "/"
 
 # PASSWORDS
 # ------------------------------------------------------------------------------

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -31,6 +31,8 @@ TEMPLATES[0]["OPTIONS"]["debug"] = DEBUG  # noqa F405
 
 # EMAIL
 # ------------------------------------------------------------------------------
+# https://docs.djangoproject.com/en/3.0/topics/email/#console-backend
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-host
 EMAIL_HOST = env("EMAIL_HOST", default="mailhog")
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-port

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.urls import include, path, re_path
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.views import defaults as default_views
 
 from dear_petition.views import index
@@ -11,6 +12,14 @@ urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
     # Your stuff: custom urls includes go here
     path("petition/", include("dear_petition.petition.urls")),
+    # Password Reset
+    path("password_reset/", auth_views.PasswordResetView.as_view(
+        subject_template_name='accounts/password_reset_subject.txt',
+        email_template_name='accounts/password_reset_email.html',
+    ), name='password_reset'),
+    path("password_reset/done/", auth_views.PasswordResetDoneView.as_view(), name='password_reset_done'),
+    path("reset/<uidb64>/<token>/", auth_views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    path("reset/done/", auth_views.PasswordResetCompleteView.as_view(), name='password_reset_complete'),
     # React SPA:
     path(r"", index, name="index"),
     re_path(r"^(?:.*)/?$", index, name="index-others"),

--- a/dear_petition/templates/accounts/password_reset_email.html
+++ b/dear_petition/templates/accounts/password_reset_email.html
@@ -1,0 +1,9 @@
+{% autoescape off %}
+Click the link below to reset the password for the DEAR Petition user: {{ user.get_username }}
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+If clicking the link above doesn't work, please copy and paste the URL in a new browser
+window instead.
+
+{% endautoescape %}

--- a/dear_petition/templates/accounts/password_reset_subject.txt
+++ b/dear_petition/templates/accounts/password_reset_subject.txt
@@ -1,0 +1,1 @@
+DEAR Petition password reset

--- a/src/components/pages/LoginPage/LoginPage.js
+++ b/src/components/pages/LoginPage/LoginPage.js
@@ -5,7 +5,10 @@ import {
   SplashLogo,
   LoginForm,
   FormErrors,
-  InputStyled
+  InputStyled,
+  PasswordInputStyled,
+  ForgotPassword,
+  PasswordWrapper
 } from './LoginPage.styled';
 import Button from '../../elements/Button/Button';
 
@@ -62,13 +65,16 @@ function Login() {
           onChange={e => setUsername(e.target.value)}
           errors={errors.username}
         />
-        <InputStyled
-          label="password"
-          type="password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-          errors={errors.password}
-        />
+        <PasswordWrapper>
+          <PasswordInputStyled
+            label="password"
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            errors={errors.password}
+          />
+          <ForgotPassword href='password_reset/'>Forgot Password?</ForgotPassword>
+        </PasswordWrapper>
         <AnimatePresence>
           {errors.detail && (
             <FormErrors

--- a/src/components/pages/LoginPage/LoginPage.styled.js
+++ b/src/components/pages/LoginPage/LoginPage.styled.js
@@ -39,3 +39,15 @@ export const FormErrors = styled(motion.div)`
 export const InputStyled = styled(Input)`
   margin: 2rem 0;
 `;
+
+export const PasswordInputStyled = styled(InputStyled)`
+  margin: 0;
+`;
+
+export const ForgotPassword = styled.a`
+  margin: 0;
+`;
+
+export const PasswordWrapper = styled.div`
+  margin: 2rem 0;
+`;


### PR DESCRIPTION
First implementation of #130 

Use the existing Django views for password reset instead of using React for now. We may go back and implement an auth REST API later.

Note that I am changing the email backend for local/debug builds to send the email to the stdout console. I used this email backend for testing the password reset functionality.