### PR TITLE
Submit petitioner name and address to generate-petition endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,10 @@ coverage report:
 
 ### Running tests with py.test
 
+#### Docker
+
+    $ docker-compose run --rm django pytest
+
+#### Without Docker
+
     $ pytest

--- a/dear_petition/petition/api/serializers.py
+++ b/dear_petition/petition/api/serializers.py
@@ -103,7 +103,7 @@ class GeneratePetitionSerializer(serializers.Serializer):
     )
     name_petitioner = serializers.CharField(label="Petitioner Name")
     address1 = serializers.CharField(label="Address Line 1")
-    address2 = serializers.CharField(label="Address Line 2")
+    address2 = serializers.CharField(label="Address Line 2", required=False, allow_blank=True)
     city = serializers.CharField(label="City")
     state = serializers.ChoiceField(choices=us_states.US_STATES)
     zip_code = serializers.CharField(label="Zip Code")

--- a/dear_petition/petition/api/serializers.py
+++ b/dear_petition/petition/api/serializers.py
@@ -101,6 +101,12 @@ class GeneratePetitionSerializer(serializers.Serializer):
     petition = serializers.ChoiceField(
         choices=[], style={"base_template": "input.html"},
     )
+    name_petitioner = serializers.CharField(label="Petitioner Name")
+    address1 = serializers.CharField(label="Address Line 1")
+    address2 = serializers.CharField(label="Address Line 2")
+    city = serializers.CharField(label="City")
+    state = serializers.ChoiceField(choices=us_states.US_STATES)
+    zip_code = serializers.CharField(label="Zip Code")
     ssn = serializers.CharField(label="SSN")
     drivers_license = serializers.CharField(label="Driver's License #")
     drivers_license_state = serializers.ChoiceField(choices=us_states.US_STATES)

--- a/dear_petition/petition/export/mapper.py
+++ b/dear_petition/petition/export/mapper.py
@@ -33,9 +33,12 @@ def map_petition(data, petition, extra={}):
 
 def map_petitioner(data, petition, extra={}):
     record = petition.batch.most_recent_record
-    data["NamePetitioner"] = getattr(
-        record, "label", None
-    )  # load.py line 28 (label is set to name attr)
+    data["NamePetitioner"] = extra.get("name_petitioner", None)
+    data["StreetAddr"] = extra.get("address1", None)
+    data["MailAddr"] = extra.get("address2", None)
+    data["City"] = extra.get("city", None)
+    data["State"] = extra.get("state", None)
+    data["ZipCode"] = extra.get("zip_code", None)
     # note: SNN and not SSN due to bug in PDF field name
     data["SNN"] = extra.get("ssn", None)
     data["DLNo"] = extra.get("drivers_license", None)

--- a/dear_petition/petition/export/tests/test_mapper.py
+++ b/dear_petition/petition/export/tests/test_mapper.py
@@ -37,9 +37,10 @@ def test_map_petition__district(data, petition):
 
 ###################### map_petitioner tests #######################
 # map_petitioner tests
-def test_map_petitioner__name(data, petition, record1):
-    mapper.map_petitioner(data, petition)
-    assert data["NamePetitioner"] == record1.label
+def test_map_petitioner__name(data, petition, extra):
+    extra["name_petitioner"] = "Test Name"
+    mapper.map_petitioner(data, petition, extra)
+    assert data["NamePetitioner"] == extra["name_petitioner"]
 
 
 def test_map_petitioner__race(data, petition, record1):
@@ -69,6 +70,40 @@ def test_map_petitioner__dob(data, petition, record1):
 def test_map_petitioner__file_no(data, petition, record1):
     mapper.map_petitioner(data, petition)
     assert data["ConsJdgmntFileNum"] == record1.file_no
+
+
+def test_map_petitioner__address(data, petition, extra):
+    extra["address1"] = "123 Test Pl."
+    extra["address2"] = "Apt 404"
+    mapper.map_petitioner(data, petition, extra)
+    assert data["StreetAddr"] == extra["address1"]
+    assert data["MailAddr"] == extra["address2"]
+
+
+def test_map_petitioner__address2_empty(data, petition, extra):
+    extra["address1"] = "123 Test Pl."
+    extra["address2"] = ""
+    mapper.map_petitioner(data, petition, extra)
+    assert data["StreetAddr"] == extra["address1"]
+    assert data["MailAddr"] == extra["address2"]
+
+
+def test_map_petitioner__city(data, petition, extra):
+    extra["city"] = "Test City"
+    mapper.map_petitioner(data, petition, extra)
+    assert data["City"] == extra["city"]
+
+
+def test_map_petitioner__state(data, petition, extra):
+    extra["state"] = constants.NORTH_CAROLINA
+    mapper.map_petitioner(data, petition, extra)
+    assert data["State"] == extra["state"]
+
+
+def test_map_petitioner__zip_code(data, petition, extra):
+    extra["zip_code"] = "27701"
+    mapper.map_petitioner(data, petition, extra)
+    assert data["ZipCode"] == extra["zip_code"]
 
 
 def test_map_petitioner__ssn(data, petition, extra):

--- a/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
+++ b/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
@@ -13,7 +13,7 @@ import Button from '../../../elements/Button/Button';
 import Axios from '../../../../service/axios';
 
 const GeneratePetitionModal = ({ closeModal, isVisible }) => {
-  const { petition, batch, address, ssn, licenseNumber, licenseState, attorney, selectedAgencies } = useContext(
+  const { petition, petitionerName, address, ssn, licenseNumber, licenseState, attorney, selectedAgencies } = useContext(
     GenerationContext
   );
 
@@ -22,11 +22,11 @@ const GeneratePetitionModal = ({ closeModal, isVisible }) => {
   const _buildPetition = () => {
     return {
       petition: petition.pk,
-      name_petitioner: batch.label,
+      name_petitioner: petitionerName,
       address1: address.address1,
       address2: address.address2,
       city: address.city,
-      state: address.state,
+      state: address.state.value,
       zip_code: address.zipCode,
       ssn,
       drivers_license: licenseNumber,

--- a/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
+++ b/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
@@ -13,7 +13,7 @@ import Button from '../../../elements/Button/Button';
 import Axios from '../../../../service/axios';
 
 const GeneratePetitionModal = ({ closeModal, isVisible }) => {
-  const { petition, ssn, licenseNumber, licenseState, attorney, selectedAgencies } = useContext(
+  const { petition, batch, address, ssn, licenseNumber, licenseState, attorney, selectedAgencies } = useContext(
     GenerationContext
   );
 
@@ -22,6 +22,12 @@ const GeneratePetitionModal = ({ closeModal, isVisible }) => {
   const _buildPetition = () => {
     return {
       petition: petition.pk,
+      name_petitioner: batch.label,
+      address1: address.address1,
+      address2: address.address2,
+      city: address.city,
+      state: address.state,
+      zip_code: address.zipCode,
       ssn,
       drivers_license: licenseNumber,
       drivers_license_state: licenseState.value,

--- a/src/components/pages/GenerationPage/GenerationInputs.js
+++ b/src/components/pages/GenerationPage/GenerationInputs.js
@@ -94,12 +94,13 @@ function GenerationInputs() {
     ssn,
     licenseNumber,
     licenseState,
-    address,
+    petitionerName,
+    setAddress,
     setAttorney,
     setSSN,
     setLicenseNumber,
     setLicenseState,
-    setAddress,
+    setPetitionerName,
     formErrors
   } = useContext(GenerationContext);
 
@@ -116,6 +117,14 @@ function GenerationInputs() {
 
   return (
     <GenerationInputsStyled>
+      <GenerationInputWrapper>
+        <Input
+          label="Petitioner"
+          value={petitionerName}
+          onChange={e => setPetitionerName(e.target.value)}
+          errors={formErrors?.petitionerName}
+        />
+      </GenerationInputWrapper>
       <FlexWrapper>
         <GenerationInputWrapper>
           <Select

--- a/src/components/pages/GenerationPage/GenerationInputs.js
+++ b/src/components/pages/GenerationPage/GenerationInputs.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { GenerationInputsStyled, GenerationInputWrapper } from './GenerationInputs.styled';
+import { FlexWrapper, GenerationInputsStyled, GenerationInputWrapper } from './GenerationInputs.styled';
 // Constants
 import US_STATES from '../../../constants/US_STATES';
 
@@ -11,6 +11,82 @@ import Input from '../../elements/Input/Input';
 import Select from '../../elements/Input/Select';
 import { GenerationContext } from './GenerationPage';
 
+function AddressInput({ setAddress, errors }) {
+  const [address1, setAddress1] = useState('');
+  const [address2, setAddress2] = useState('');
+  const [city, setCity] = useState('');
+  const [state, setState] = useState({ label: 'NC', value: 'NC' });
+  const [zipCode, setZipCode] = useState('');
+  return (
+    <FlexWrapper>
+      <GenerationInputWrapper>
+        <Input
+          label="Address Line 1"
+          value={address1}
+          onChange={e => {
+            const val = e.target.value;
+            setAddress1(val);
+            setAddress((prev) => ({ ...prev, address1: val }));
+          }}
+          errors={errors.address}
+        />
+      </GenerationInputWrapper>
+
+      <GenerationInputWrapper>
+        <Input
+          label="Address Line 2"
+          value={address2}
+          onChange={e => {
+            const val = e.target.value;
+            setAddress2(val);
+            setAddress((prev) => ({ ...prev, address2: val }));
+          }}
+        />
+      </GenerationInputWrapper>
+
+      <GenerationInputWrapper>
+        <Input
+          label="City"
+          value={city}
+          onChange={e => {
+            const val = e.target.value;
+            setCity(val);
+            setAddress((prev) => ({ ...prev, city: val }));
+          }}
+          errors={errors.city}
+        />
+      </GenerationInputWrapper>
+
+      <GenerationInputWrapper>
+        <Select
+          label="State"
+          value={state}
+          onChange={val => {
+            setState(val);
+            setAddress((prev) => ({ ...prev, state: val }));
+          }}
+          options={US_STATES.map(state => ({ value: state[0], label: state[0] }))}
+          errors={errors.state}
+        />
+      </GenerationInputWrapper>
+
+      <GenerationInputWrapper>
+        <Input
+          label="Zip Code"
+          value={zipCode}
+          maxLength={5}
+          onChange={e => {
+            const val = e.target.value;
+            setZipCode(val);
+            setAddress((prev) => ({ ...prev, zipCode: val }));
+          }}
+          errors={errors.zipCode}
+        />
+      </GenerationInputWrapper>
+    </FlexWrapper>
+  );
+}
+
 function GenerationInputs() {
   const [attornies, setAttornies] = useState([]);
   const {
@@ -18,10 +94,12 @@ function GenerationInputs() {
     ssn,
     licenseNumber,
     licenseState,
+    address,
     setAttorney,
     setSSN,
     setLicenseNumber,
     setLicenseState,
+    setAddress,
     formErrors
   } = useContext(GenerationContext);
 
@@ -38,44 +116,48 @@ function GenerationInputs() {
 
   return (
     <GenerationInputsStyled>
-      <GenerationInputWrapper>
-        <Select
-          label="Attorney"
-          value={attorney}
-          onChange={val => setAttorney(val)}
-          options={attornies.map(att => ({ value: att.pk, label: att.name }))}
-          errors={formErrors?.attorney}
-        />
-      </GenerationInputWrapper>
+      <FlexWrapper>
+        <GenerationInputWrapper>
+          <Select
+            label="Attorney"
+            value={attorney}
+            onChange={val => setAttorney(val)}
+            options={attornies.map(att => ({ value: att.pk, label: att.name }))}
+            errors={formErrors?.attorney}
+          />
+        </GenerationInputWrapper>
 
-      <GenerationInputWrapper>
-        <Input
-          label="SSN"
-          value={ssn}
-          onChange={e => setSSN(e.target.value)}
-          maxLength={11} // in case they want to add dashes?
-          errors={formErrors?.ssn}
-        />
-      </GenerationInputWrapper>
+        <GenerationInputWrapper>
+          <Input
+            label="SSN"
+            value={ssn}
+            onChange={e => setSSN(e.target.value)}
+            maxLength={11} // in case they want to add dashes?
+            errors={formErrors?.ssn}
+          />
+        </GenerationInputWrapper>
 
-      <GenerationInputWrapper>
-        <Input
-          label="License #"
-          value={licenseNumber}
-          onChange={e => setLicenseNumber(e.target.value)}
-          errors={formErrors?.licenseNumber}
-        />
-      </GenerationInputWrapper>
+        <GenerationInputWrapper>
+          <Input
+            label="License #"
+            value={licenseNumber}
+            onChange={e => setLicenseNumber(e.target.value)}
+            errors={formErrors?.licenseNumber}
+          />
+        </GenerationInputWrapper>
 
-      <GenerationInputWrapper>
-        <Select
-          label="License state"
-          value={licenseState}
-          onChange={val => setLicenseState(val)}
-          options={US_STATES.map(state => ({ value: state[0], label: state[0] }))}
-          errors={formErrors?.licenseState}
-        />
-      </GenerationInputWrapper>
+        <GenerationInputWrapper>
+          <Select
+            label="License state"
+            value={licenseState}
+            onChange={val => setLicenseState(val)}
+            options={US_STATES.map(state => ({ value: state[0], label: state[0] }))}
+            errors={formErrors?.licenseState}
+          />
+        </GenerationInputWrapper>
+      </FlexWrapper>
+
+      <AddressInput setAddress={setAddress} errors={formErrors} />
     </GenerationInputsStyled>
   );
 }

--- a/src/components/pages/GenerationPage/GenerationInputs.styled.js
+++ b/src/components/pages/GenerationPage/GenerationInputs.styled.js
@@ -2,8 +2,12 @@ import styled from 'styled-components';
 import { smallerThanTabletLandscape } from '../../../styles/media';
 
 export const GenerationInputsStyled = styled.div`
+`;
+
+export const FlexWrapper = styled.div`
   margin: 2rem 0 4rem 0;
   display: flex;
+  flex-flow: row wrap;
   justify-content: center;
 
   @media (${smallerThanTabletLandscape}) {
@@ -14,7 +18,5 @@ export const GenerationInputsStyled = styled.div`
 `;
 
 export const GenerationInputWrapper = styled.div`
-  &:not(:first-child) {
-    margin-left: 4rem;
-  }
+  margin-right: 4rem;
 `;

--- a/src/components/pages/GenerationPage/GenerationPage.js
+++ b/src/components/pages/GenerationPage/GenerationPage.js
@@ -17,15 +17,18 @@ import PetitionListItem from './PetitionListItem';
 
 export const GenerationContext = createContext(null);
 
+const DEFAULT_STATE_LABEL = { label: 'NC', value: 'NC' };
+
 function GenerationPage() {
   const { batchId } = useParams();
   const [loading, setLoading] = useState();
   const [batch, setBatch] = useState();
   const [petition, setPetition] = useState();
-  const [address, setAddress] = useState({ state: 'NC' });
+  const [petitionerName, setPetitionerName] = useState();
+  const [address, setAddress] = useState({ state: DEFAULT_STATE_LABEL });
   const [ssn, setSSN] = useState('');
   const [licenseNumber, setLicenseNumber] = useState('');
-  const [licenseState, setLicenseState] = useState({ label: 'NC', value: 'NC' });
+  const [licenseState, setLicenseState] = useState(DEFAULT_STATE_LABEL);
   const [attorney, setAttorney] = useState('');
   const [selectedAgencies, setSelectedAgencies] = useState([]);
   const [showGenerationModal, setShowGenerationModal] = useState(false);
@@ -36,6 +39,7 @@ function GenerationPage() {
     Axios.get(`/batch/${batchId}/`)
       .then(({ data }) => {
         setBatch(data);
+        setPetitionerName(data?.label);
         setLoading(false);
       })
       .catch(error => {
@@ -47,6 +51,10 @@ function GenerationPage() {
   const _petitionDataIsValid = () => {
     let isValid = true;
     const errors = {};
+    if (!petitionerName) {
+      errors.petitionerName = ['This field is required'];
+      isValid = false;
+    }
     if (!ssn) {
       errors.ssn = ['This field is required'];
       isValid = false;
@@ -110,6 +118,8 @@ function GenerationPage() {
     setSelectedAgencies,
     showGenerationModal,
     setShowGenerationModal,
+    petitionerName,
+    setPetitionerName,
     formErrors,
     setFormErrors,
     handlePetitionSelect
@@ -122,7 +132,6 @@ function GenerationPage() {
           <h2>Loading...</h2>
         ) : (
           <GenerationContentStyled>
-            <h2>{batch?.label}</h2>
             <GenerationInputs />
             <PetitionsList>
               {batch?.petitions?.map(petition => {

--- a/src/components/pages/GenerationPage/GenerationPage.js
+++ b/src/components/pages/GenerationPage/GenerationPage.js
@@ -22,6 +22,7 @@ function GenerationPage() {
   const [loading, setLoading] = useState();
   const [batch, setBatch] = useState();
   const [petition, setPetition] = useState();
+  const [address, setAddress] = useState({ state: 'NC' });
   const [ssn, setSSN] = useState('');
   const [licenseNumber, setLicenseNumber] = useState('');
   const [licenseState, setLicenseState] = useState({ label: 'NC', value: 'NC' });
@@ -62,6 +63,22 @@ function GenerationPage() {
       errors.attorney = ['This field is required'];
       isValid = false;
     }
+    if (!address?.address1) {
+      errors.address = ['This field is required'];
+      isValid = false;
+    }
+    if (!address?.city) {
+      errors.city = ['This field is required'];
+      isValid = false;
+    }
+    if (!address?.state) {
+      errors.state = ['This field is required'];
+      isValid = false;
+    }
+    if (!address?.zipCode) {
+      errors.zipCode = ['This field is required'];
+      isValid = false;
+    }
 
     setFormErrors(errors);
 
@@ -79,6 +96,8 @@ function GenerationPage() {
   const context = {
     batch,
     petition,
+    address,
+    setAddress,
     ssn,
     setSSN,
     licenseNumber,

--- a/src/constants/US_STATES.js
+++ b/src/constants/US_STATES.js
@@ -50,4 +50,8 @@ export default [
   ['WY', 'Wyoming'],
   ['AK', 'Alaska'],
   ['HI', 'Hawaii']
-];
+].sort((a, b) => {
+  if (a[0] > b[0]) return 1;
+  if (b[0] > a[0]) return -1;
+  return 0;
+});


### PR DESCRIPTION
Resolves #139, resolves #141 

This PR adds the following fields to be submitted during petition generation:

* Address Line 1
* Address Line 2 (optional)
* City
* State
* Zip Code

Additionally, the petitioner name is submitted to the endpoint automatically (derived from batch['label']).

### Misc Changes

* Updated the readme with pytest instructions for docker
* Sorted the array of US States so that the dropdown menu would list the states in alphabetical order