### PR TITLE
Fix docker frontend service setup and enable hot reloading

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,14 +1,14 @@
 FROM node:13.12.0-alpine
 
-RUN mkdir -p /app/frontend
-WORKDIR /app/frontend
+WORKDIR /app/
 
 ENV PATH /app/node_modules/.bin:$PATH
 
-COPY package*.json ./
+# Copy project contents since the mounted volume is not available yet
+COPY . ./
+
+# Dependencies will be persisted in /app/ volume under /app/node_modules
 RUN npm install
 RUN npm install react-scripts@3.4.1 -g
-
-COPY . ./
 
 CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ The staging API server is useful for developers who do not wish to build a local
 
 ### Local Backend
 
-Developers who wish to use a local version of both the frontend and backend must set the `proxy` variable in `package.json` to the following:
+Developers who wish to use a local version of both the frontend and backend must change the `proxy` variable in `package.json`.
 
-```diff
--  "proxy": "https://dear-petition-staging.herokuapp.com/",
-+  "proxy": "http://localhost:8000",
+#### Docker Example
+
+When using `docker-compose up -d` to run both the backend and frontend within docker containers, use the following configuration:
+
+```json
+"proxy": "http://django:8000",
 ```
 
 


### PR DESCRIPTION
I was improving my development workflow and noticed I wasn't able to access the react app after running `docker-compose up` in a fresh VM. I found that the container errored during the `npm run start` command:

```bash
$ docker-compose ps
          Name                        Command                State                  Ports              
-------------------------------------------------------------------------------------------------------
dear-petition_django_1     /entrypoint /start               Up         0.0.0.0:8000->8000/tcp          
dear-petition_frontend_1   docker-entrypoint.sh npm r ...   Exit 254                                   
dear-petition_jupyter_1    /entrypoint /start-jupyter       Up         0.0.0.0:8001->8888/tcp          
dear-petition_mailhog_1    MailHog                          Up         1025/tcp, 0.0.0.0:8025->8025/tcp
dear-petition_postgres_1   docker-entrypoint.sh postgres    Up         5432/tcp                        
dear-petition_redis_1      docker-entrypoint.sh redis ...   Up         6379/tcp 
```

Checking the logs showed that there were missing files in the `/app/frontend` directory.

```bash
$ docker-compose logs frontend
Attaching to dear-petition_frontend_1
frontend_1  | npm ERR! code ENOENT
frontend_1  | npm ERR! syscall open
frontend_1  | npm ERR! path /app/frontend/package.json
frontend_1  | npm ERR! errno -2
frontend_1  | npm ERR! enoent ENOENT: no such file or directory, open '/app/frontend/package.json'
frontend_1  | npm ERR! enoent This is related to npm not being able to find a file.
frontend_1  | npm ERR! enoent 
frontend_1  | 
frontend_1  | npm ERR! A complete log of this run can be found in:
frontend_1  | npm ERR!     /root/.npm/_logs/2020-07-21T17_59_29_579Z-debug.log
```

I checked the container's contents and saw that the `/app/frontend/` folder was indeed empty. The problem is that during `docker-compose build` we create an `/app/frontend/` folder and populate it with necessary project files, but when we run `docker-compose up` we override the created folder with the mounted volume `/app/`.

With my changes, we get rid of the `/app/frontend` directory and instead run `npm run start` from the root of our mounted volume `/app/`. The benefit of this approach is that hot reloading is enabled so that our React code changes are immediately reflected within the app.