### PR TITLE
Fix issue where argon2 ffi library not installed

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 pytz==2019.1  # https://github.com/stub42/pytz
 python-slugify==3.0.2  # https://github.com/un33k/python-slugify
 Pillow==6.2.0  # https://github.com/python-pillow/Pillow
-argon2-cffi==19.1.0  # https://github.com/hynek/argon2_cffi
+argon2-cffi==20.1.0  # https://github.com/hynek/argon2_cffi
 whitenoise==4.1.2  # https://github.com/evansd/whitenoise
 redis==3.2.1  # https://github.com/antirez/redis
 celery==4.3.0  # pyup: < 5.0  # https://github.com/celery/celery


### PR DESCRIPTION
Error I was seeing:

```
docker-compose run --rm django python manage.py createsuperuser
  File "/usr/lib/python3.7/site-packages/django/contrib/auth/hashers.py", line 78, in make_password
    return hasher.encode(password, salt)
  File "/usr/lib/python3.7/site-packages/django/contrib/auth/hashers.py", line 304, in encode
    argon2 = self._load_library()
  File "/usr/lib/python3.7/site-packages/django/contrib/auth/hashers.py", line 182, in _load_library
    (self.__class__.__name__, e))
ValueError: Couldn't load 'Argon2PasswordHasher' algorithm library: No module named 'argon2._ffi'
```

Strangely, I saw that the library was indeed installed:

```
docker-compose run --rm django pip list installed | grep argon
Starting dear-petition_postgres_1 ... done
Starting dear-petition_mailhog_1  ... done
argon2-cffi                   19.1.0
```

It seems like some nested dependencies were updated recently, causing issues with how the cffi dependency was installed. If needed, I can track down which dependency was the problem before merging.