### PR TITLE
Fix Download button for generated petitions

### DIFF
--- a/src/components/pages/GenerationPage/GeneratePetitionModal/AgencyAutocomplete.js
+++ b/src/components/pages/GenerationPage/GeneratePetitionModal/AgencyAutocomplete.js
@@ -69,7 +69,6 @@ const AgencyAutocomplete = ({ ...props }) => {
   };
 
   const addAgency = thisAgency => {
-    console.log(thisAgency);
     setSuggestionValue('');
     setSelectedAgencies([...selectedAgencies, thisAgency]);
   };

--- a/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
+++ b/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
@@ -19,8 +19,6 @@ const GeneratePetitionModal = ({ closeModal, isVisible }) => {
   );
   const [pdfWindow, setPdfWindow] = useState({ handle: null, url: null});
 
-  console.log("render");
-
   const _buildPetition = () => {
     return {
       petition: petition.pk,
@@ -57,17 +55,14 @@ const GeneratePetitionModal = ({ closeModal, isVisible }) => {
     setPdfWindow({ handle: window.open(url), url });
   };
 
-  const closePdf = () => {
-    setPdfWindow(({ handle, url }) => {
-      console.log("CLEAN UP");
-      console.log(handle);
-      console.log(url);
-      if (url)
-        window.URL.revokeObjectURL(url);
-      if (handle)
-        handle.close();
-      return { handle: null, url: null };
-    });
+  const closePdf = async () => {
+    const { url, handle } = pdfWindow;
+    if (url)
+      window.URL.revokeObjectURL(url);
+    if (handle)
+      handle.close();
+
+    setPdfWindow({ handle: null, url: null });
     closeModal();
   };
 

--- a/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
+++ b/src/components/pages/GenerationPage/GeneratePetitionModal/GeneratePetitionModal.js
@@ -55,7 +55,7 @@ const GeneratePetitionModal = ({ closeModal, isVisible }) => {
     setPdfWindow({ handle: window.open(url), url });
   };
 
-  const closePdf = async () => {
+  const closePdf = () => {
     const { url, handle } = pdfWindow;
     if (url)
       window.URL.revokeObjectURL(url);

--- a/src/components/pages/GenerationPage/GenerationInputs.js
+++ b/src/components/pages/GenerationPage/GenerationInputs.js
@@ -105,14 +105,18 @@ function GenerationInputs() {
   } = useContext(GenerationContext);
 
   useEffect(() => {
+    let isMounted = true;
     (async function() {
       try {
         const { data } = await Axios.get('/contact/?category=attorney');
-        setAttornies(data?.results || []);
+        // only update state when component is mounted
+        if (isMounted)
+          setAttornies(data?.results || []);
       } catch (error) {
         console.error(error);
       }
     })();
+    return () => isMounted = false;
   }, []);
 
   return (

--- a/src/components/pages/GenerationPage/GenerationPage.js
+++ b/src/components/pages/GenerationPage/GenerationPage.js
@@ -92,10 +92,13 @@ function GenerationPage() {
     return isValid;
   };
 
-  const handlePetitionSelect = (petition) => {
+  const validatePetitionSelect = (petition) => {
     setFormErrors({});
     if (_petitionDataIsValid()) {
       setSelectedPetition(petition);
+      return true;
+    } else {
+      return false;
     }
   };
 
@@ -133,7 +136,7 @@ function GenerationPage() {
                 <PetitionListItem
                   key={petition.pk}
                   petition={petition}
-                  handlePetitionSelect={handlePetitionSelect} />
+                  validatePetitionSelect={validatePetitionSelect} />
               )}
             </PetitionsList>
           </GenerationContentStyled>

--- a/src/components/pages/GenerationPage/GenerationPage.js
+++ b/src/components/pages/GenerationPage/GenerationPage.js
@@ -92,7 +92,7 @@ function GenerationPage() {
     return isValid;
   };
 
-  const handlePetitionSelect = petition => {
+  const handlePetitionSelect = (petition) => {
     setFormErrors({});
     if (_petitionDataIsValid()) {
       setSelectedPetition(petition);
@@ -133,7 +133,7 @@ function GenerationPage() {
                 <PetitionListItem
                   key={petition.pk}
                   petition={petition}
-                  selectPetition={() => handlePetitionSelect(petition)} />
+                  handlePetitionSelect={handlePetitionSelect} />
               )}
             </PetitionsList>
           </GenerationContentStyled>

--- a/src/components/pages/GenerationPage/GenerationPage.js
+++ b/src/components/pages/GenerationPage/GenerationPage.js
@@ -23,15 +23,14 @@ function GenerationPage() {
   const { batchId } = useParams();
   const [loading, setLoading] = useState();
   const [batch, setBatch] = useState();
-  const [petition, setPetition] = useState();
-  const [petitionerName, setPetitionerName] = useState();
+  const [selectedPetition, setSelectedPetition] = useState();
+  const [petitionerName, setPetitionerName] = useState('');
   const [address, setAddress] = useState({ state: DEFAULT_STATE_LABEL });
   const [ssn, setSSN] = useState('');
   const [licenseNumber, setLicenseNumber] = useState('');
   const [licenseState, setLicenseState] = useState(DEFAULT_STATE_LABEL);
   const [attorney, setAttorney] = useState('');
   const [selectedAgencies, setSelectedAgencies] = useState([]);
-  const [showGenerationModal, setShowGenerationModal] = useState(false);
   const [formErrors, setFormErrors] = useState({});
 
   useEffect(() => {
@@ -93,17 +92,16 @@ function GenerationPage() {
     return isValid;
   };
 
-  const handlePetitionSelect = selectedPetition => {
+  const handlePetitionSelect = petition => {
     setFormErrors({});
     if (_petitionDataIsValid()) {
-      setPetition(selectedPetition);
-      setShowGenerationModal(true);
+      setSelectedPetition(petition);
     }
   };
 
   const context = {
     batch,
-    petition,
+    petition: selectedPetition,
     address,
     setAddress,
     ssn,
@@ -116,13 +114,10 @@ function GenerationPage() {
     setAttorney,
     selectedAgencies,
     setSelectedAgencies,
-    showGenerationModal,
-    setShowGenerationModal,
     petitionerName,
     setPetitionerName,
     formErrors,
     setFormErrors,
-    handlePetitionSelect
   };
 
   return (
@@ -134,9 +129,12 @@ function GenerationPage() {
           <GenerationContentStyled>
             <GenerationInputs />
             <PetitionsList>
-              {batch?.petitions?.map(petition => {
-                return <PetitionListItem key={petition.pk} petition={petition} />;
-              })}
+              {batch?.petitions?.map(petition =>
+                <PetitionListItem
+                  key={petition.pk}
+                  petition={petition}
+                  selectPetition={() => handlePetitionSelect(petition)} />
+              )}
             </PetitionsList>
           </GenerationContentStyled>
         )}

--- a/src/components/pages/GenerationPage/PetitionListItem.js
+++ b/src/components/pages/GenerationPage/PetitionListItem.js
@@ -2,17 +2,23 @@ import React, { useState } from 'react';
 import { PetitionListItemStyled, PetitionCellStyled } from './PetitionListItem.styled';
 import GeneratePetitionModal from './GeneratePetitionModal/GeneratePetitionModal';
 
-function PetitionListItem({ petition, selectPetition }) {
-  const [isVisible, setIsVisible] = useState(false);
+function PetitionListItem({ petition, handlePetitionSelect }) {
+  const [isVisible, setVisible] = useState(false);
+  const handleClick = () => {
+    handlePetitionSelect(petition);
+    setVisible(true);
+  };
   return (
     <>
-      <PetitionListItemStyled onClick={() => { selectPetition(); setIsVisible(true); } }>
+      <PetitionListItemStyled onClick={handleClick}>
         <PetitionCellStyled>{petition.form_type}</PetitionCellStyled>
         <PetitionCellStyled>{petition.county} County</PetitionCellStyled>
         <PetitionCellStyled>{petition.jurisdiction}</PetitionCellStyled>
       </PetitionListItemStyled>
       {isVisible && (
-        <GeneratePetitionModal isVisible={isVisible} closeModal={() => setIsVisible(false)}/>
+        <GeneratePetitionModal
+          isVisible={isVisible}
+          closeModal={() => setVisible(false)}/>
       )}
     </>
   );

--- a/src/components/pages/GenerationPage/PetitionListItem.js
+++ b/src/components/pages/GenerationPage/PetitionListItem.js
@@ -1,24 +1,19 @@
-import React, { useContext } from 'react';
+import React, { useState } from 'react';
 import { PetitionListItemStyled, PetitionCellStyled } from './PetitionListItem.styled';
-import { GenerationContext } from './GenerationPage';
 import GeneratePetitionModal from './GeneratePetitionModal/GeneratePetitionModal';
 
-function PetitionListItem({ petition }) {
-  const { showGenerationModal, setShowGenerationModal, handlePetitionSelect } = useContext(
-    GenerationContext
-  );
-
+function PetitionListItem({ petition, selectPetition }) {
+  const [isVisible, setIsVisible] = useState(false);
   return (
     <>
-      <PetitionListItemStyled onClick={() => handlePetitionSelect(petition)}>
+      <PetitionListItemStyled onClick={() => { selectPetition(); setIsVisible(true); } }>
         <PetitionCellStyled>{petition.form_type}</PetitionCellStyled>
         <PetitionCellStyled>{petition.county} County</PetitionCellStyled>
         <PetitionCellStyled>{petition.jurisdiction}</PetitionCellStyled>
       </PetitionListItemStyled>
-      <GeneratePetitionModal
-        isVisible={showGenerationModal}
-        closeModal={() => setShowGenerationModal(false)}
-      />
+      {isVisible && (
+        <GeneratePetitionModal isVisible={isVisible} closeModal={() => setIsVisible(false)}/>
+      )}
     </>
   );
 }

--- a/src/components/pages/GenerationPage/PetitionListItem.js
+++ b/src/components/pages/GenerationPage/PetitionListItem.js
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { PetitionListItemStyled, PetitionCellStyled } from './PetitionListItem.styled';
 import GeneratePetitionModal from './GeneratePetitionModal/GeneratePetitionModal';
 
-function PetitionListItem({ petition, handlePetitionSelect }) {
+function PetitionListItem({ petition, validatePetitionSelect }) {
   const [isVisible, setVisible] = useState(false);
   const handleClick = () => {
-    handlePetitionSelect(petition);
-    setVisible(true);
+    if (validatePetitionSelect(petition)) {
+      setVisible(true);
+    }
   };
   return (
     <>

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -10,9 +10,8 @@ const useKeyPress = (key, action) => {
             if (e.key === key) action();
         }
         window.addEventListener('keyup', handleKeyPress);
-        console.log("Added event listener");
         return () => window.removeEventListener('keyup', handleKeyPress);
-    }, [key]);
+    }, [key, action]);
 };
 
 export default useKeyPress;

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -1,20 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 /**
  * useKeyPress
  * @param {string} key - the name of the key to respond to, compared against event.key
  * @param {function} action - the action to perform on key press
  */
 const useKeyPress = (key, action) => {
-    console.log(key);
     useEffect(() => {
         function handleKeyPress(e) {
-            console.log("KEYPRESS");
             if (e.key === key) action();
         }
         window.addEventListener('keyup', handleKeyPress);
         console.log("Added event listener");
         return () => window.removeEventListener('keyup', handleKeyPress);
-    }, []);
+    }, [key]);
 };
 
 export default useKeyPress;

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -1,17 +1,20 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 /**
  * useKeyPress
  * @param {string} key - the name of the key to respond to, compared against event.key
  * @param {function} action - the action to perform on key press
  */
 const useKeyPress = (key, action) => {
+    console.log(key);
     useEffect(() => {
         function handleKeyPress(e) {
-            if (e.key === 'Escape') action();
+            console.log("KEYPRESS");
+            if (e.key === key) action();
         }
         window.addEventListener('keyup', handleKeyPress);
+        console.log("Added event listener");
         return () => window.removeEventListener('keyup', handleKeyPress);
-    }, [action]);
+    }, []);
 };
 
 export default useKeyPress;


### PR DESCRIPTION
Fixes #162 

### `revokeObjectURL()`

We needed to hold off on calling `revokeObjectURL()` to free up the `pdfBlob` reference created by `createObjectURL()`. By calling `revokeObjectURL()` too early, the result was an invalid reference upon download which triggered the `Network Error`.

My solution was to ensure that cleanup code `revokeObjectURL()` and `window.close()` were called upon generating a new petition or closing the `GeneratePetitionModal`. I added `window.close()` to close the window displaying the pdf to avoid any confusion about which pdfUrl references were still active and to avoid any accidental `Network Error` issues

### Fix misc. warning message

There was a warning:

```
Can’t perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

The warning was caused by our `setAttornies()` state update within an asynchronous method in the `useEffect()` hook. The message is specifically triggered when `setAttornies()` was called after the `GenerationInputs` component was unmounted.

The solution is to add a check to see if the component is still mounted before calling `setAttornies()`.