### PR TITLE
Improve proxy configuration and support proxied admin pages

### DIFF
--- a/.envs/.local/.frontend
+++ b/.envs/.local/.frontend
@@ -1,0 +1,2 @@
+CHOKIDAR_USEPOLLING=true
+API_PROXY=http://django:8000

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,6 @@
 {
   "extends": ["airbnb", "prettier"],
   "plugins": ["prettier"],
-  "env": {
-    "cypress/globals": true
-  },
   "rules": {
     "prettier/prettier": ["error"],
     "react/jsx-filename-extension": [

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Begin by cloning the repository:
 git clone git@github.com:deardurham/dear-petition.git
 ```
 
+### 🚀 Docker Quick Start (recommended)
+
+```bash
+docker-compose up -d
+docker-compose run --rm django python manage.py createsuperuser
+```
 
 ## Frontend Development
 
@@ -32,22 +38,23 @@ npm run start
 
 ### Staging Backend
 
-By default, the frontend development server [proxies requests](https://create-react-app.dev/docs/proxying-api-requests-in-development/) to [a staging API server](https://dear-petition-staging.herokuapp.com/).
+While running `npm run start`, the frontend development server will by default [proxy API requests](https://create-react-app.dev/docs/proxying-api-requests-in-development/) to the [DEAR staging server](https://dear-petition-staging.herokuapp.com/).
 
-The staging API server is useful for developers who do not wish to build a local backend implementation. New developers must have a user set up on the staging server in order to test most frontend functionality.
+The staging server is useful for developers who do not wish to build and run a local backend. New developers must request the development team to have a user created on the staging server.
 
 
 ### Local Backend
 
-Developers who wish to use a local version of both the frontend and backend must change the `proxy` variable in `package.json`.
+Developers who wish to use a local version of both the frontend and backend must set the `API_PROXY` environment variable. Note: This is not necessary when using Docker.
 
-#### Docker Example
-
-When using `docker-compose up -d` to run both the backend and frontend within docker containers, use the following configuration:
-
-```json
-"proxy": "http://django:8000",
+```bash
+API_PROXY=http://localhost:8000 npm run start
 ```
+
+
+### Docker Proxy Override
+
+WIP
 
 
 ## Backend Development (with Docker)

--- a/README.md
+++ b/README.md
@@ -7,21 +7,15 @@ project for creating petition forms.
 [![Build Status](https://travis-ci.org/deardurham/dear-petition.svg?branch=master)](https://travis-ci.org/deardurham/dear-petition)
 [![Black code style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-
-## Local Development
-
-Begin by cloning the repository:
-
-```
-git clone git@github.com:deardurham/dear-petition.git
-```
-
-### 🚀 Docker Quick Start (recommended)
+## 🚀 Docker Quick Start (recommended)
 
 ```bash
+git clone git@github.com:deardurham/dear-petition.git
+cd dear-petition
 docker-compose up -d
 docker-compose run --rm django python manage.py createsuperuser
 ```
+
 
 ## Frontend Development
 
@@ -36,25 +30,29 @@ npm run start
 ```
 
 
-### Staging Backend
+### API Proxy Configuration
 
-While running `npm run start`, the frontend development server will by default [proxy API requests](https://create-react-app.dev/docs/proxying-api-requests-in-development/) to the [DEAR staging server](https://dear-petition-staging.herokuapp.com/).
+The Petition Generator app uses a React frontend with a Django REST API backend. In the development environment, the React development server and Django backend will likely be hosted on different ports, and thus hosted on different urls. This causes issues when the frontend code sends API requests, such as a login request. The solution is to [proxy the API requests](https://create-react-app.dev/docs/proxying-api-requests-in-development/) to the url of the backend.
 
-The staging server is useful for developers who do not wish to build and run a local backend. New developers must request the development team to have a user created on the staging server.
+#### Docker Container
 
+When the frontend is run using docker, the `API_PROXY` environment variable is set to `http://django:8000`.
 
-### Local Backend
-
-Developers who wish to use a local version of both the frontend and backend must set the `API_PROXY` environment variable. Note: This is not necessary when using Docker.
+You can override the this proxy url by setting `OVERRIDE_API_PROXY`:
 
 ```bash
-API_PROXY=http://localhost:8000 npm run start
+OVERRIDE_API_PROXY=https://dear-petition-staging.herokuapp.com/ docker-compose up -d
 ```
 
+#### Local Frontend
 
-### Docker Proxy Override
+When using `npm run start` to run the frontend, the `API_PROXY` environment variable is unset. The fallback proxy is set to the staging backend url.
 
-WIP
+You can set the proxy url by either setting `OVERRIDE_API_PROXY` or `API_PROXY`:
+
+```bash
+API_PROXY=http://localhost:8000 docker-compose up -d
+```
 
 
 ## Backend Development (with Docker)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,10 @@ services:
     volumes:
       - /app/node_modules
       - ./:/app/
+    env_file:
+      - ./.envs/.local/.frontend
     environment:
-      - CHOKIDAR_USEPOLLING=true
+      - OVERRIDE_API_PROXY
 
   mailhog:
     image: mailhog/mailhog:v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5168,15 +5168,6 @@
         }
       }
     },
-    "eslint-plugin-cypress": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.10.3.tgz",
-      "integrity": "sha512-CvFeoCquShfO8gHNIKA1VpUTz78WtknMebLemBd1lRbcmJNjwpqCqpQYUG/XVja8GjdX/e2TJXYa+EUBxehtUg==",
-      "dev": true,
-      "requires": {
-        "globals": "^11.12.0"
-      }
-    },
     "eslint-plugin-flowtype": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "dearpetition",
   "version": "0.1.0",
   "private": true,
-  "proxy": "https://dear-petition-staging.herokuapp.com/",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-regular-svg-icons": "^5.13.0",
@@ -27,7 +26,6 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-cypress": "^2.10.3",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,15 @@
+const proxyMiddleware = require('http-proxy-middleware');
+
+// docker-compose will avoid using the fallback due to always having one of OVERRIDE_API_PROXY or API_PROXY set
+// Note: non-docker frontend needs to set one of the env vars to `http://localhost:8000` to proxy local backend
+const FALLBACK_PROXY = "https://dear-petition-staging.herokuapp.com/";
+
+module.exports = function(app) {
+    const proxyOptions = proxyMiddleware({
+        target: process.env.OVERRIDE_API_PROXY || process.env.API_PROXY || FALLBACK_PROXY,
+        changeOrigin: true,
+    });
+    app.use('/petition/api', proxyOptions);
+    app.use('/admin(-\\w+)?/', proxyOptions);
+    app.use('/static/admin', proxyOptions);
+};


### PR DESCRIPTION
* Use `http://django:8000` when using docker-compose by default
* Added `OVERRIDE_API_PROXY` environment variable to override default
* The admin pages are now also proxied
* Removed unused dependency