### PR TITLE
Revert to celery 4.x

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ Pillow==9.0.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==20.1.0  # https://github.com/hynek/argon2_cffi
 whitenoise==5.2.0  # https://github.com/evansd/whitenoise
 redis==3.2.1  # https://github.com/antirez/redis
-celery==5.2.2  # pyup: < 5.0  # https://github.com/celery/celery
+celery==4.4.7  # pyup: < 5.0  # https://github.com/celery/celery
 flower==0.9.5  # https://github.com/mher/flower
 pyjwt==2.1.0
 


### PR DESCRIPTION
Revert 7af5a44ed285cf4432e0f49ac9148c7a45452ce1 until we assess a celery 5.x upgrade