### PR TITLE
Use dash in csrf header name

### DIFF
--- a/src/constants/authConstants.js
+++ b/src/constants/authConstants.js
@@ -1,4 +1,4 @@
-export const CSRF_HEADER_KEY = 'X_CSRFTOKEN';
+export const CSRF_HEADER_KEY = 'X-CSRFTOKEN';
 export const CSRF_COOKIE_NAME = 'csrftoken';
 export const CSRF_TOKEN_LS_KEY = 'CSRF_TOKEN';
 export const JWT_COOKIE_KEY = 'Authorization';


### PR DESCRIPTION
Hidden in Django's [HttpRequest.META](https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpRequest.META) docs, there's a special note related to `runserver`:

> Note that [runserver](https://docs.djangoproject.com/en/3.2/ref/django-admin/#django-admin-runserver) strips all headers with underscores in the name, so you won’t see them in META. This prevents header-spoofing based on ambiguity between underscores and dashes both being normalizing to underscores in WSGI environment variables. It matches the behavior of Web servers like Nginx and Apache 2.4+.

(Django's [CVE-2015-0219](https://docs.djangoproject.com/en/4.0/releases/security/#january-13-2015-cve-2015-0219) documents this in more detail).

As noted, nginx performs a similar security measure, but we don't run nginx on Heroku. We only run `uwsgi` on production and `runserver_plus` in our dev Dockerfile, neither of which do this. So only **runserver** was impacted by this, which likely explains why I only saw this while developing #303 (assuming everyone else runs the old Dockerfile for backend development).

To support the default runserver too, we just need to use `X-CSRFTOKEN` as our header name.