### PR TITLE
Flesh out str() and repr() implementations for models

### DIFF
--- a/dear_petition/common/models.py
+++ b/dear_petition/common/models.py
@@ -1,0 +1,55 @@
+from itertools import chain
+
+
+class PrintableModelMixin(object):
+    """
+    Mixin used by Models to implement str() and repr().  It includes all fields in the model including uneditable fields
+    and many to many relationships. If desired, fields can be excluded from output.
+
+    See discussion at:
+    https://stackoverflow.com/questions/21925671/convert-django-model-object-to-dict-with-all-of-the-fields-intact
+    """
+
+    def __str__(self, exclude_fields=[]):
+        """
+        Long values are truncated.
+
+        Example output:
+        Petition [id=1, created=2022-12-18 03:15:20.468997+00:00, modified=2022-12-18 03:15:20.468997+00:00,
+        form_type=AOC-CR-287, batch=1, county=Independent and Sovereign County of Durham North C..., jurisdiction=D,
+        offense_records=[1], agencies=[1, 2]]
+        """
+        max_length = 50
+        return '{} [{}]'.format(
+            self.__class__.__name__,
+            ', '.join('{}={}'.format(k, truncate(v, max_length)) for k, v in self.to_dict(exclude_fields).items()))
+
+    def __repr__(self, exclude_fields=[]):
+        """
+        Example output:
+        {'id': 1, 'created': datetime.datetime(2022, 12, 18, 3, 18, 40, 926603, tzinfo=<UTC>),
+        'modified': datetime.datetime(2022, 12, 18, 3, 18, 40, 926603, tzinfo=<UTC>), 'form_type': 'AOC-CR-287',
+        'batch': 1, 'county': 'Independent and Sovereign County of Durham North Carolina', 'jurisdiction': 'D',
+        'offense_records': [1], 'agencies': [1, 2]}
+        """
+        return str(self.to_dict(exclude_fields))
+
+    def to_dict(instance, exclude_fields=[]):
+        opts = instance._meta
+        data = {}
+        for f in chain(opts.concrete_fields, opts.private_fields):
+            if f.name not in exclude_fields:
+                data[f.name] = f.value_from_object(instance)
+        for f in opts.many_to_many:
+            if f.name not in exclude_fields:
+                data[f.name] = [i.id for i in f.value_from_object(instance)]
+        return data
+
+
+def truncate(value, max_length):
+    """
+    If value has more than max_length characters, truncate it to max_length and indicate it has been truncated by adding
+    "..." at the end of the value.  For example, truncate("Lorem ipsum dolor sit", 10) would return "Lorem ipsu..."
+    """
+    v = str(value)
+    return v if len(v) <= max_length else (v[:max_length] + '...')

--- a/dear_petition/petition/models.py
+++ b/dear_petition/petition/models.py
@@ -20,6 +20,7 @@ import ciprs_reader
 from localflavor.us import us_states
 from dear_petition.users.models import User
 from dear_petition.users import constants as uc
+from dear_petition.common.models import PrintableModelMixin
 from . import constants as pc
 
 from .constants import (
@@ -38,7 +39,7 @@ from .utils import make_datetime_aware
 logger = logging.getLogger(__name__)
 
 
-class CIPRSRecordManager(models.Manager):
+class CIPRSRecordManager(PrintableModelMixin, models.Manager):
     def create_record(self, batch, label, data):
         """Extract General, Case, and Defendant details from data
 
@@ -54,7 +55,7 @@ class CIPRSRecordManager(models.Manager):
         ciprs_record.refresh_record_from_data()
 
 
-class CIPRSRecord(models.Model):
+class CIPRSRecord(PrintableModelMixin, models.Model):
 
     batch = models.ForeignKey("Batch", related_name="records", on_delete=models.CASCADE)
     date_uploaded = models.DateTimeField(auto_now_add=True)
@@ -73,9 +74,6 @@ class CIPRSRecord(models.Model):
     )
 
     objects = CIPRSRecordManager()
-
-    def __str__(self):
-        return f"{self.label} {self.file_no} ({self.pk})"
 
     class Meta:
         verbose_name = "CIPRSRecord"
@@ -104,7 +102,7 @@ class CIPRSRecord(models.Model):
         refresh_record_from_data(self)
 
 
-class Offense(models.Model):
+class Offense(PrintableModelMixin, models.Model):
     ciprs_record = models.ForeignKey(
         "CIPRSRecord", related_name="offenses", on_delete=models.CASCADE
     )
@@ -116,11 +114,8 @@ class Offense(models.Model):
     verdict = models.CharField(max_length=256, blank=True)
     plea = models.CharField(max_length=256, blank=True)
 
-    def __str__(self):
-        return f"{self.id} ({self.ciprs_record.file_no})"
 
-
-class OffenseRecord(models.Model):
+class OffenseRecord(PrintableModelMixin, models.Model):
     offense = models.ForeignKey(
         "Offense", related_name="offense_records", on_delete=models.CASCADE
     )
@@ -130,12 +125,8 @@ class OffenseRecord(models.Model):
     severity = models.CharField(max_length=256)
     description = models.CharField(max_length=256)
 
-    def __str__(self):
-        ciprs_record = self.offense.ciprs_record
-        return f"{ciprs_record.file_no} {self.action} {self.severity} ({self.id})"
 
-
-class Contact(models.Model):
+class Contact(PrintableModelMixin, models.Model):
     name = models.CharField(max_length=512)
     category = models.CharField(
         max_length=16, choices=CONTACT_CATEGORIES, default="agency"
@@ -146,11 +137,8 @@ class Contact(models.Model):
     state = models.CharField(choices=us_states.US_STATES, max_length=64, blank=True)
     zipcode = models.CharField("ZIP Code", max_length=16, blank=True)
 
-    def __str__(self):
-        return self.name
 
-
-class Batch(models.Model):
+class Batch(PrintableModelMixin, models.Model):
 
     label = models.CharField(max_length=2048, blank=True)
     date_uploaded = models.DateTimeField(auto_now_add=True)
@@ -158,9 +146,6 @@ class Batch(models.Model):
 
     class Meta:
         verbose_name_plural = "Batches"
-
-    def __str__(self):
-        return f"{self.pk}: {self.label}"
 
     def get_absolute_url(self):
         return reverse("create-petition", kwargs={"pk": self.pk})
@@ -221,16 +206,13 @@ class Batch(models.Model):
         return today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
 
 
-class BatchFile(models.Model):
+class BatchFile(PrintableModelMixin, models.Model):
     batch = models.ForeignKey(Batch, related_name="files", on_delete=models.CASCADE)
     date_uploaded = models.DateTimeField(auto_now_add=True)
     file = models.FileField(upload_to="ciprs/")
 
-    def __str__(self):
-        return f"{self.file.name}"
 
-
-class Comment(models.Model):
+class Comment(PrintableModelMixin, models.Model):
 
     user = models.ForeignKey(User, related_name="comments", on_delete=models.DO_NOTHING)
     text = models.TextField()
@@ -255,7 +237,7 @@ class Comment(models.Model):
         super(Comment, self).save(*args, **kwargs)
 
 
-class Petition(TimeStampedModel):
+class Petition(PrintableModelMixin, TimeStampedModel):
 
     form_type = models.CharField(choices=FORM_TYPES, max_length=255)
     batch = models.ForeignKey(Batch, on_delete=models.CASCADE, related_name="petitions")
@@ -265,9 +247,6 @@ class Petition(TimeStampedModel):
         OffenseRecord, related_name="petitions", through="PetitionOffenseRecord"
     )
     agencies = models.ManyToManyField(Contact, related_name="+")
-
-    def __str__(self):
-        return f"{self.form_type} {self.get_jurisdiction_display()} in {self.county}"
 
     def get_offense_record_paginator(self, filter_active=True):
         from dear_petition.petition.etl.paginator import OffenseRecordPaginator
@@ -345,7 +324,7 @@ DataPetition = namedtuple("DataPetition", ["form_type", "data_only"], defaults=[
 DataPetitionDocument = namedtuple("DataPetitionDocument", ["petition"])
 
 
-class PetitionDocument(models.Model):
+class PetitionDocument(PrintableModelMixin, models.Model):
     petition = models.ForeignKey(
         Petition, on_delete=models.CASCADE, related_name="documents"
     )
@@ -374,19 +353,14 @@ class PetitionDocument(models.Model):
     def county(self):
         return self.petition.county
 
-    def __str__(self):
-        attachment = " attachment " if self.is_attachment else " "
-        jurisdiction = self.petition.get_jurisdiction_display()
-        return f"{self.county} {self.form_type} {jurisdiction}{attachment}({self.id})"
 
-
-class PetitionOffenseRecord(models.Model):
+class PetitionOffenseRecord(PrintableModelMixin, models.Model):
     petition = models.ForeignKey(Petition, on_delete=models.CASCADE)
     offense_record = models.ForeignKey(OffenseRecord, on_delete=models.CASCADE)
     active = models.BooleanField(default=True)
 
 
-class GeneratedPetition(TimeStampedModel):
+class GeneratedPetition(PrintableModelMixin, TimeStampedModel):
     username = models.CharField(max_length=uc.NAME_MAX_LENGTH)
     form_type = models.CharField(choices=FORM_TYPES, max_length=255)
     number_of_charges = models.IntegerField()

--- a/dear_petition/petition/tests/test_models.py
+++ b/dear_petition/petition/tests/test_models.py
@@ -1,0 +1,93 @@
+import pytest
+
+from dear_petition.users.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_printable_model_mixin_petition(batch, petition, contact1, contact2, offense_record1):
+    """
+    Test PrintableModelMixin str() and repr() methods using Petition model because Petition has many to many
+    relationships.
+    """
+
+    # set many to many relationships
+    petition.agencies.add(contact1)
+    petition.agencies.add(contact2)
+    petition.offense_records.add(offense_record1)
+
+    # set a value greater than 50 characters to test truncation
+    petition.county = "Independent and Sovereign County of Durham North Carolina"
+
+    # assertions
+    expected_str = ", ".join([
+        "Petition [id=" + str(petition.id),
+        "created=" + str(petition.created),
+        "modified=" + str(petition.modified),
+        "form_type=AOC-CR-287",
+        "batch=" + str(batch.id),
+        "county=Independent and Sovereign County of Durham North C...",
+        "jurisdiction=D",
+        "offense_records=[" + str(offense_record1.id) + "]",
+        "agencies=[" + str(contact1.id) + ", " + str(contact2.id) + "]]"
+    ])
+    assert (str(petition) == expected_str)
+
+    expected_repr = ", ".join([
+        "{'id': " + repr(petition.id),
+        "'created': " + repr(petition.created),
+        "'modified': " + repr(petition.modified),
+        "'form_type': 'AOC-CR-287'",
+        "'batch': " + repr(batch.id),
+        "'county': 'Independent and Sovereign County of Durham North Carolina'",
+        "'jurisdiction': 'D'",
+        "'offense_records': [" + repr(offense_record1.id) + "]",
+        "'agencies': [" + repr(contact1.id) + ", " + repr(contact2.id) + "]}"
+    ])
+    assert (repr(petition) == expected_repr)
+
+
+def test_printable_model_mixin_user():
+    """
+    Test PrintableModelMixin str() and repr() methods using User model because User has a field that should be excluded.
+    """
+
+    # create model object
+    user = UserFactory(username="tmarshall", email="tmarshall@supremecourt.gov", name="Thurgood Marshall")
+
+    # assertions
+    expected_str = ", ".join([
+        "User [id=" + str(user.id),
+        "last_login=None",
+        "is_superuser=False",
+        "username=tmarshall",
+        "first_name=",
+        "last_name=",
+        "email=tmarshall@supremecourt.gov",
+        "is_staff=False",
+        "is_active=True",
+        "date_joined=" + str(user.date_joined),
+        "name=Thurgood Marshall",
+        "last_generated_petition_time=None",
+        "groups=[]",
+        "user_permissions=[]]"
+    ])
+    assert (str(user) == expected_str)
+
+    expected_repr = ", ".join([
+        "{'id': " + repr(user.id),
+        "'last_login': None",
+        "'is_superuser': False",
+        "'username': 'tmarshall'",
+        "'first_name': ''",
+        "'last_name': ''",
+        "'email': 'tmarshall@supremecourt.gov'",
+        "'is_staff': False",
+        "'is_active': True",
+        "'date_joined': " + repr(user.date_joined),
+        "'name': 'Thurgood Marshall'",
+        "'last_generated_petition_time': None",
+        "'groups': []",
+        "'user_permissions': []}"
+    ])
+    assert (repr(user) == expected_repr)

--- a/dear_petition/sendgrid/models.py
+++ b/dear_petition/sendgrid/models.py
@@ -1,11 +1,12 @@
 from django.db import models
 from django.contrib.postgres.fields import JSONField
 
+from dear_petition.common.models import PrintableModelMixin
 
-class Email(models.Model):
+
+class Email(PrintableModelMixin, models.Model):
     """
     SendGrid Parse Email
-
     https://docs.sendgrid.com/for-developers/parsing-email/setting-up-the-inbound-parse-webhook#default-parameters
     """
 
@@ -20,11 +21,8 @@ class Email(models.Model):
     attachment_count = models.PositiveIntegerField(default=0)
     date_created = models.DateTimeField(auto_now_add=True)
 
-    def __str__(self):
-        return f"{self.subject[:20]} to {self.recipient}"
 
-
-class Attachment(models.Model):
+class Attachment(PrintableModelMixin, models.Model):
     """Email Attachment"""
 
     name = models.CharField(max_length=1024)
@@ -34,6 +32,3 @@ class Attachment(models.Model):
     email = models.ForeignKey(
         Email, related_name="attachments", on_delete=models.CASCADE
     )
-
-    def __str__(self):
-        return self.name

--- a/dear_petition/users/models.py
+++ b/dear_petition/users/models.py
@@ -1,16 +1,15 @@
 from django.contrib.auth.models import AbstractUser
 from django.db.models import CharField, DateField, ForeignKey
-from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from django.urls import reverse
 from django.core.mail import send_mail
 
-
 from . import constants as uc
+from ..common.models import PrintableModelMixin
 
 
-class User(AbstractUser):
+class User(PrintableModelMixin, AbstractUser):
 
     name = CharField(_("Name of User"), blank=True, max_length=uc.NAME_MAX_LENGTH)
     last_generated_petition_time = DateField(null=True)
@@ -21,3 +20,13 @@ class User(AbstractUser):
     def send_email(self, subject, message, send_anyway=False):
         if settings.ENVIRONMENT == "PRODUCTION" or send_anyway:
             send_mail(subject, message, uc.FROM_EMAIL_ADDRESS, [self.email])
+
+    def __str__(self):
+        # for security reasons, do not include the password field
+        exclude_fields = ["password"]
+        return super().__str__(exclude_fields)
+
+    def __repr__(self):
+        # for security reasons, do not include the password field
+        exclude_fields = ["password"]
+        return super().__repr__(exclude_fields)


### PR DESCRIPTION
Fleshed out str() and repr() implementations for all models.  Generally speaking, all fields are included (including many to many relationships).

For example, for the Petition model:

str(petition) returns:
`Petition [id=1, created=2022-12-19 02:27:19.778391+00:00, modified=2022-12-19 02:27:19.778391+00:00, form_type=AOC-CR-287, batch=1, county=Independent and Sovereign County of Durham North C..., jurisdiction=D, offense_records=[1], agencies=[1, 2]]`

repr(petition) returns:
`{'id': 1, 'created': datetime.datetime(2022, 12, 19, 2, 27, 19, 778391, tzinfo=<UTC>), 'modified': datetime.datetime(2022, 12, 19, 2, 27, 19, 778391, tzinfo=<UTC>), 'form_type': 'AOC-CR-287', 'batch': 1, 'county': 'Independent and Sovereign County of Durham North Carolina', 'jurisdiction': 'D', 'offense_records': [1], 'agencies': [1, 2]}`