### PR TITLE
Remove __str__ from PrintableModelMixin

### DIFF
--- a/dear_petition/common/models.py
+++ b/dear_petition/common/models.py
@@ -3,26 +3,12 @@ from itertools import chain
 
 class PrintableModelMixin(object):
     """
-    Mixin used by Models to implement str() and repr().  It includes all fields in the model including uneditable fields
+    Mixin used by Models to implement repr().  It includes all fields in the model including uneditable fields
     and many to many relationships. If desired, fields can be excluded from output.
 
     See discussion at:
     https://stackoverflow.com/questions/21925671/convert-django-model-object-to-dict-with-all-of-the-fields-intact
     """
-
-    def __str__(self, exclude_fields=[]):
-        """
-        Long values are truncated.
-
-        Example output:
-        Petition [id=1, created=2022-12-18 03:15:20.468997+00:00, modified=2022-12-18 03:15:20.468997+00:00,
-        form_type=AOC-CR-287, batch=1, county=Independent and Sovereign County of Durham North C..., jurisdiction=D,
-        offense_records=[1], agencies=[1, 2]]
-        """
-        max_length = 50
-        return '{} [{}]'.format(
-            self.__class__.__name__,
-            ', '.join('{}={}'.format(k, truncate(v, max_length)) for k, v in self.to_dict(exclude_fields).items()))
 
     def __repr__(self, exclude_fields=[]):
         """
@@ -44,12 +30,3 @@ class PrintableModelMixin(object):
             if f.name not in exclude_fields:
                 data[f.name] = [i.id for i in f.value_from_object(instance)]
         return data
-
-
-def truncate(value, max_length):
-    """
-    If value has more than max_length characters, truncate it to max_length and indicate it has been truncated by adding
-    "..." at the end of the value.  For example, truncate("Lorem ipsum dolor sit", 10) would return "Lorem ipsu..."
-    """
-    v = str(value)
-    return v if len(v) <= max_length else (v[:max_length] + '...')

--- a/dear_petition/petition/models.py
+++ b/dear_petition/petition/models.py
@@ -83,6 +83,9 @@ class CIPRSRecord(PrintableModelMixin, models.Model):
 
     objects = CIPRSRecordManager()
 
+    def __str__(self):
+        return f"{self.label} {self.file_no} ({self.pk})"
+
     class Meta:
         verbose_name = "CIPRSRecord"
 
@@ -121,6 +124,9 @@ class Offense(PrintableModelMixin, models.Model):
     disposition_method = models.CharField(max_length=256)
     verdict = models.CharField(max_length=256, blank=True)
     plea = models.CharField(max_length=256, blank=True)
+
+    def __str__(self):
+        return f"{self.id} ({self.ciprs_record.file_no})"
 
 
 class OffenseRecord(PrintableModelMixin, models.Model):
@@ -171,6 +177,9 @@ class Contact(PrintableModelMixin, models.Model):
     phone_number = PhoneNumberField(null=True, blank=True)
     email = models.EmailField(max_length=254, null=True, blank=True)
 
+    def __str__(self):
+        return self.name
+
 
 class Batch(PrintableModelMixin, models.Model):
 
@@ -183,6 +192,9 @@ class Batch(PrintableModelMixin, models.Model):
 
     class Meta:
         verbose_name_plural = "Batches"
+
+    def __str__(self):
+        return f"{self.pk}: {self.label}"
 
     def get_absolute_url(self):
         return reverse("create-petition", kwargs={"pk": self.pk})
@@ -259,6 +271,9 @@ class BatchFile(PrintableModelMixin, models.Model):
     date_uploaded = models.DateTimeField(auto_now_add=True)
     file = models.FileField(upload_to=get_batch_file_upload_path)
 
+    def __str__(self):
+        return f"{self.file.name}"
+
 
 class Comment(PrintableModelMixin, models.Model):
 
@@ -295,6 +310,9 @@ class Petition(PrintableModelMixin, TimeStampedModel):
         OffenseRecord, related_name="petitions", through="PetitionOffenseRecord"
     )
     agencies = models.ManyToManyField(Contact, related_name="+")
+
+    def __str__(self):
+        return f"{self.form_type} {self.get_jurisdiction_display()} in {self.county}"
 
     def get_offense_record_paginator(self, filter_active=True):
         from dear_petition.petition.etl.paginator import OffenseRecordPaginator
@@ -400,6 +418,11 @@ class PetitionDocument(PrintableModelMixin, models.Model):
     @property
     def county(self):
         return self.petition.county
+
+    def __str__(self):
+        attachment = " attachment " if self.is_attachment else " "
+        jurisdiction = self.petition.get_jurisdiction_display()
+        return f"{self.county} {self.form_type} {jurisdiction}{attachment}({self.id})"
 
 
 class PetitionOffenseRecord(PrintableModelMixin, models.Model):

--- a/dear_petition/petition/tests/test_models.py
+++ b/dear_petition/petition/tests/test_models.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 
 def test_printable_model_mixin_petition(batch, petition, contact1, contact2, offense_record1):
     """
-    Test PrintableModelMixin str() and repr() methods using Petition model because Petition has many to many
+    Test PrintableModelMixin repr() method using Petition model because Petition has many to many
     relationships.
     """
 
@@ -22,30 +22,14 @@ def test_printable_model_mixin_petition(batch, petition, contact1, contact2, off
     petition.agencies.add(contact2)
     petition.offense_records.add(offense_record1)
 
-    # set a value greater than 50 characters to test truncation
-    petition.county = "Independent and Sovereign County of Durham North Carolina"
-
     # assertions
-    expected_str = ", ".join([
-        "Petition [id=" + str(petition.id),
-        "created=" + str(petition.created),
-        "modified=" + str(petition.modified),
-        "form_type=AOC-CR-287",
-        "batch=" + str(batch.id),
-        "county=Independent and Sovereign County of Durham North C...",
-        "jurisdiction=D",
-        "offense_records=[" + str(offense_record1.id) + "]",
-        "agencies=[" + str(contact1.id) + ", " + str(contact2.id) + "]]"
-    ])
-    assert (str(petition) == expected_str)
-
     expected_repr = ", ".join([
         "{'id': " + repr(petition.id),
         "'created': " + repr(petition.created),
         "'modified': " + repr(petition.modified),
         "'form_type': 'AOC-CR-287'",
         "'batch': " + repr(batch.id),
-        "'county': 'Independent and Sovereign County of Durham North Carolina'",
+        "'county': 'DURHAM'",
         "'jurisdiction': 'D'",
         "'offense_records': [" + repr(offense_record1.id) + "]",
         "'agencies': [" + repr(contact1.id) + ", " + repr(contact2.id) + "]}"
@@ -55,31 +39,13 @@ def test_printable_model_mixin_petition(batch, petition, contact1, contact2, off
 
 def test_printable_model_mixin_user():
     """
-    Test PrintableModelMixin str() and repr() methods using User model because User has a field that should be excluded.
+    Test PrintableModelMixin repr() method using User model because User has a field that should be excluded.
     """
 
     # create model object
     user = UserFactory(username="tmarshall", email="tmarshall@supremecourt.gov", name="Thurgood Marshall")
 
     # assertions
-    expected_str = ", ".join([
-        "User [id=" + str(user.id),
-        "last_login=None",
-        "is_superuser=False",
-        "username=tmarshall",
-        "first_name=",
-        "last_name=",
-        "email=tmarshall@supremecourt.gov",
-        "is_staff=False",
-        "is_active=True",
-        "date_joined=" + str(user.date_joined),
-        "name=Thurgood Marshall",
-        "last_generated_petition_time=None",
-        "groups=[]",
-        "user_permissions=[]]"
-    ])
-    assert (str(user) == expected_str)
-
     expected_repr = ", ".join([
         "{'id': " + repr(user.id),
         "'last_login': None",

--- a/dear_petition/sendgrid/models.py
+++ b/dear_petition/sendgrid/models.py
@@ -7,6 +7,7 @@ from dear_petition.common.models import PrintableModelMixin
 class Email(PrintableModelMixin, models.Model):
     """
     SendGrid Parse Email
+
     https://docs.sendgrid.com/for-developers/parsing-email/setting-up-the-inbound-parse-webhook#default-parameters
     """
 
@@ -21,6 +22,9 @@ class Email(PrintableModelMixin, models.Model):
     attachment_count = models.PositiveIntegerField(default=0)
     date_created = models.DateTimeField(auto_now_add=True)
 
+    def __str__(self):
+        return f"{self.subject[:20]} to {self.recipient}"
+
 
 class Attachment(PrintableModelMixin, models.Model):
     """Email Attachment"""
@@ -32,3 +36,6 @@ class Attachment(PrintableModelMixin, models.Model):
     email = models.ForeignKey(
         Email, related_name="attachments", on_delete=models.CASCADE
     )
+
+    def __str__(self):
+        return self.name

--- a/dear_petition/users/models.py
+++ b/dear_petition/users/models.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.core.mail import send_mail
 
 from . import constants as uc
-from ..common.models import PrintableModelMixin
+from dear_petition.common.models import PrintableModelMixin
 
 
 class User(PrintableModelMixin, AbstractUser):
@@ -20,11 +20,6 @@ class User(PrintableModelMixin, AbstractUser):
     def send_email(self, subject, message, send_anyway=False):
         if settings.ENVIRONMENT == "PRODUCTION" or send_anyway:
             send_mail(subject, message, uc.FROM_EMAIL_ADDRESS, [self.email])
-
-    def __str__(self):
-        # for security reasons, do not include the password field
-        exclude_fields = ["password"]
-        return super().__str__(exclude_fields)
 
     def __repr__(self):
         # for security reasons, do not include the password field


### PR DESCRIPTION
The Django Admin UI uses __str__ extensively, so it is better to revert to the less verbose __str__ implementations