### PR TITLE
Fix attorney address issue #345

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,7 @@ dear_petition/static/js/project.min.js
 /build
 
 # misc
+notes.txt
 .DS_Store
 .env.local
 .env.development.local

--- a/.gitignore
+++ b/.gitignore
@@ -308,7 +308,6 @@ dear_petition/static/js/project.min.js
 /build
 
 # misc
-notes.txt
 .DS_Store
 .env.local
 .env.development.local

--- a/src/components/pages/GenerationPage/GenerationInput/AddressInput.js
+++ b/src/components/pages/GenerationPage/GenerationInput/AddressInput.js
@@ -26,7 +26,8 @@ const TextInput = styled(Input)`
 `;
 
 export default function AddressInput({ address, setAddress, disabled, errors, onClearError }) {
-  const { address1, address2, city, stateAsObject, zipcode } = address;
+  const { address1, address2, city, state, zipcode } = address;
+  const stateObj = typeof state === 'string' ? { value: state, label: state } : state;
   const handleChange = (key, value) => {
     if (disabled) return;
     setAddress((prev) => ({ ...prev, [key]: value }));
@@ -58,7 +59,7 @@ export default function AddressInput({ address, setAddress, disabled, errors, on
         <Select
           label="State"
           disabled={disabled}
-          value={stateAsObject}
+          value={stateObj}
           onChange={(value) => handleChange('state', value)}
           options={US_STATES.map((s) => ({ value: s[0], label: s[0] }))}
           errors={!disabled && errors.state}

--- a/src/components/pages/GenerationPage/GenerationInput/AddressInput.js
+++ b/src/components/pages/GenerationPage/GenerationInput/AddressInput.js
@@ -26,7 +26,7 @@ const TextInput = styled(Input)`
 `;
 
 export default function AddressInput({ address, setAddress, disabled, errors, onClearError }) {
-  const { address1, address2, city, state, zipCode } = address;
+  const { address1, address2, city, state, zipcode } = address;
   const handleChange = (key, value) => {
     if (disabled) return;
     setAddress((prev) => ({ ...prev, [key]: value }));
@@ -66,7 +66,7 @@ export default function AddressInput({ address, setAddress, disabled, errors, on
         <TextInput
           label="Zip Code"
           disabled={disabled}
-          value={zipCode}
+          value={zipcode}
           maxLength={5}
           onChange={(e) => handleChange('zipCode', e.target.value)}
           errors={!disabled && errors.zipCode}

--- a/src/components/pages/GenerationPage/GenerationInput/AddressInput.js
+++ b/src/components/pages/GenerationPage/GenerationInput/AddressInput.js
@@ -26,7 +26,7 @@ const TextInput = styled(Input)`
 `;
 
 export default function AddressInput({ address, setAddress, disabled, errors, onClearError }) {
-  const { address1, address2, city, state, zipcode } = address;
+  const { address1, address2, city, stateAsObject, zipcode } = address;
   const handleChange = (key, value) => {
     if (disabled) return;
     setAddress((prev) => ({ ...prev, [key]: value }));
@@ -58,7 +58,7 @@ export default function AddressInput({ address, setAddress, disabled, errors, on
         <Select
           label="State"
           disabled={disabled}
-          value={state}
+          value={stateAsObject}
           onChange={(value) => handleChange('state', value)}
           options={US_STATES.map((s) => ({ value: s[0], label: s[0] }))}
           errors={!disabled && errors.state}

--- a/src/components/pages/GenerationPage/GenerationInput/AttorneyInput.jsx
+++ b/src/components/pages/GenerationPage/GenerationInput/AttorneyInput.jsx
@@ -19,6 +19,10 @@ const TextInput = styled(Input)`
 export default function AttorneyInput({ attorney, setAttorney, errors, onClearError }) {
   const [triggerSuggestionsFetch] = useLazySearchAttorniesQuery();
   const { address1, address2, city, state, zipcode } = attorney;
+  const stateAsObject = {
+    label: state,
+    value: state,
+  };
 
   return (
     <div className="mt-2">
@@ -50,7 +54,7 @@ export default function AttorneyInput({ attorney, setAttorney, errors, onClearEr
       {attorney && (
         <div>
           <TextInput label="Name" value={attorney.name} disabled />
-          <AddressInput address={{ address1, address2, city, state, zipcode }} disabled />
+          <AddressInput address={{ address1, address2, city, stateAsObject, zipcode }} disabled />
         </div>
       )}
     </div>

--- a/src/components/pages/GenerationPage/GenerationInput/AttorneyInput.jsx
+++ b/src/components/pages/GenerationPage/GenerationInput/AttorneyInput.jsx
@@ -19,10 +19,6 @@ const TextInput = styled(Input)`
 export default function AttorneyInput({ attorney, setAttorney, errors, onClearError }) {
   const [triggerSuggestionsFetch] = useLazySearchAttorniesQuery();
   const { address1, address2, city, state, zipcode } = attorney;
-  const stateAsObject = {
-    label: state,
-    value: state,
-  };
 
   return (
     <div className="mt-2">
@@ -54,7 +50,7 @@ export default function AttorneyInput({ attorney, setAttorney, errors, onClearEr
       {attorney && (
         <div>
           <TextInput label="Name" value={attorney.name} disabled />
-          <AddressInput address={{ address1, address2, city, stateAsObject, zipcode }} disabled />
+          <AddressInput address={{ address1, address2, city, state, zipcode }} disabled />
         </div>
       )}
     </div>

--- a/src/components/pages/GenerationPage/GenerationInput/AttorneyInput.jsx
+++ b/src/components/pages/GenerationPage/GenerationInput/AttorneyInput.jsx
@@ -18,7 +18,7 @@ const TextInput = styled(Input)`
 
 export default function AttorneyInput({ attorney, setAttorney, errors, onClearError }) {
   const [triggerSuggestionsFetch] = useLazySearchAttorniesQuery();
-  const { address1, address2, city, state, zipCode } = attorney;
+  const { address1, address2, city, state, zipcode } = attorney;
 
   return (
     <div className="mt-2">
@@ -50,7 +50,7 @@ export default function AttorneyInput({ attorney, setAttorney, errors, onClearEr
       {attorney && (
         <div>
           <TextInput label="Name" value={attorney.name} disabled />
-          <AddressInput address={{ address1, address2, city, state, zipCode }} disabled />
+          <AddressInput address={{ address1, address2, city, state, zipcode }} disabled />
         </div>
       )}
     </div>


### PR DESCRIPTION
AttorneyInput was trying to pass a string into the Select component within AddressInput. The Select component requires an object to be passed into the 'value' prop. The added stateObj will convert any string passed in as the 'state' property of address into an object with the shape expected by Select.

The zipcode issue was a typo: zipCode > zipcode.