### PR TITLE
Fix sortable headers on UsersPage

### DIFF
--- a/src/components/pages/UsersPage/UsersPage.js
+++ b/src/components/pages/UsersPage/UsersPage.js
@@ -191,13 +191,7 @@ const UsersPage = () => {
               </button>
             </div>
           </TableFlexRow>
-          <UsersTable
-            users={data?.results || []}
-            sortBy={sortBy}
-            onSortBy={onSortBy}
-            ordering={ordering}
-            setOrdering={setOrdering}
-          />
+          <UsersTable users={data?.results || []} sortBy={sortBy} onSortBy={onSortBy} />
         </FlexColumn>
       </UsersSection>
     </PageBase>

--- a/src/components/pages/UsersPage/UsersPage.js
+++ b/src/components/pages/UsersPage/UsersPage.js
@@ -79,10 +79,16 @@ const UsersPage = () => {
   const [limit, setLimit] = useState(limitSizes[0]);
   const [offset, setOffset] = useState(0);
   const [ordering, setOrdering] = useState('username');
+  const [sortBy, setSortBy] = useState({ field: 'username', dir: 'dsc' });
   const [search, setSearch] = useState('');
   const [formValue, setFormValue] = useState('');
   const debounceSearch = useDebounce((value) => setSearch(value), { timeout: 400 });
   const { data } = useUsersQuery({ params: { limit: limit.value, offset, ordering, search } });
+  const onSortBy = (field, dir) => {
+    setSortBy({ field, dir });
+  };
+  console.log(`here's sortBy state:`);
+  console.log(sortBy);
 
   const numUsers = data?.count ?? 0;
   useEffect(() => {
@@ -180,7 +186,14 @@ const UsersPage = () => {
               </button>
             </div>
           </TableFlexRow>
-          <UsersTable users={data?.results || []} ordering={ordering} setOrdering={setOrdering} />
+          {/* added sortBy={sortBy} & onSortBy={onSortBy} /> */}
+          <UsersTable
+            users={data?.results || []}
+            sortBy={sortBy}
+            onSortBy={onSortBy}
+            ordering={ordering}
+            setOrdering={setOrdering}
+          />
         </FlexColumn>
       </UsersSection>
     </PageBase>

--- a/src/components/pages/UsersPage/UsersPage.js
+++ b/src/components/pages/UsersPage/UsersPage.js
@@ -83,12 +83,17 @@ const UsersPage = () => {
   const [search, setSearch] = useState('');
   const [formValue, setFormValue] = useState('');
   const debounceSearch = useDebounce((value) => setSearch(value), { timeout: 400 });
-  const { data } = useUsersQuery({ params: { limit: limit.value, offset, ordering, search } });
+  const { data } = useUsersQuery({
+    queryString: new URLSearchParams([
+      ['search', search],
+      ['ordering', ordering],
+      ['offset', offset],
+      ['limit', limit.value],
+    ]).toString(),
+  });
   const onSortBy = (field, dir) => {
     setSortBy({ field, dir });
   };
-  console.log(`here's sortBy state:`);
-  console.log(sortBy);
 
   const numUsers = data?.count ?? 0;
   useEffect(() => {
@@ -186,7 +191,6 @@ const UsersPage = () => {
               </button>
             </div>
           </TableFlexRow>
-          {/* added sortBy={sortBy} & onSortBy={onSortBy} /> */}
           <UsersTable
             users={data?.results || []}
             sortBy={sortBy}

--- a/src/components/pages/UsersPage/UsersPage.js
+++ b/src/components/pages/UsersPage/UsersPage.js
@@ -75,18 +75,22 @@ const calculatePageIndices = (current, numPages) => {
   return [Math.max(1, startIndex), Math.min(endIndex, numPages)];
 };
 
+const getOrdering = ({ field, dir }) => {
+  const sortDir = dir === 'asc' ? '-' : '';
+  return `${sortDir}${field}`;
+};
+
 const UsersPage = () => {
   const [limit, setLimit] = useState(limitSizes[0]);
   const [offset, setOffset] = useState(0);
-  const [ordering, setOrdering] = useState('username');
-  const [sortBy, setSortBy] = useState({ field: 'username', dir: 'dsc' });
+  const [sortBy, setSortBy] = useState({ field: 'username', dir: 'asc' });
   const [search, setSearch] = useState('');
   const [formValue, setFormValue] = useState('');
   const debounceSearch = useDebounce((value) => setSearch(value), { timeout: 400 });
   const { data } = useUsersQuery({
     queryString: new URLSearchParams([
       ['search', search],
-      ['ordering', ordering],
+      ['ordering', getOrdering(sortBy)],
       ['offset', offset],
       ['limit', limit.value],
     ]).toString(),

--- a/src/components/pages/UsersPage/UsersPage.js
+++ b/src/components/pages/UsersPage/UsersPage.js
@@ -83,7 +83,7 @@ const getOrdering = ({ field, dir }) => {
 const UsersPage = () => {
   const [limit, setLimit] = useState(limitSizes[0]);
   const [offset, setOffset] = useState(0);
-  const [sortBy, setSortBy] = useState({ field: 'username', dir: 'asc' });
+  const [sortBy, setSortBy] = useState({ field: 'username', dir: 'dsc' });
   const [search, setSearch] = useState('');
   const [formValue, setFormValue] = useState('');
   const debounceSearch = useDebounce((value) => setSearch(value), { timeout: 400 });

--- a/src/components/pages/UsersPage/UsersTable.js
+++ b/src/components/pages/UsersPage/UsersTable.js
@@ -214,16 +214,21 @@ const UserRow = ({ user, setModalVisible }) => {
   );
 };
 
-const UsersTable = ({ ordering, users, setOrdering }) => (
+// in AgenciesTable, the ordering stuff is set in the TableHeader
+// TODO change props to users, sortBy, onSortBy
+const UsersTable = ({ users, sortBy, onSortBy, ordering, setOrdering }) => (
   <UsersTableStyled numColumns={5}>
-    <TableHeader>
+    <TableHeader sortedHeader={sortBy.field} sortDir={sortBy.dir} onSelectColumn={onSortBy}>
+      {/* <TableHeader> */}
       <SortableHeader field="username" ordering={ordering} setOrdering={setOrdering}>
         Username
       </SortableHeader>
       <SortableHeader field="email" ordering={ordering} setOrdering={setOrdering}>
         Email
       </SortableHeader>
-      <TableCell header>Admin?</TableCell>
+      <SortableHeader field="admin" setOrdering={setOrdering}>
+        Admin?
+      </SortableHeader>
       <SortableHeader field="last_login" ordering={ordering} setOrdering={setOrdering}>
         Last Login
       </SortableHeader>

--- a/src/components/pages/UsersPage/UsersTable.js
+++ b/src/components/pages/UsersPage/UsersTable.js
@@ -214,7 +214,6 @@ const UserRow = ({ user, setModalVisible }) => {
   );
 };
 
-// TODO change props to users, sortBy, onSortBy
 const UsersTable = ({ users, sortBy, onSortBy }) => (
   <UsersTableStyled numColumns={5}>
     <TableHeader sortedHeader={sortBy.field} sortDir={sortBy.dir} onSelectColumn={onSortBy}>

--- a/src/components/pages/UsersPage/UsersTable.js
+++ b/src/components/pages/UsersPage/UsersTable.js
@@ -214,24 +214,14 @@ const UserRow = ({ user, setModalVisible }) => {
   );
 };
 
-// in AgenciesTable, the ordering stuff is set in the TableHeader
 // TODO change props to users, sortBy, onSortBy
-const UsersTable = ({ users, sortBy, onSortBy, ordering, setOrdering }) => (
+const UsersTable = ({ users, sortBy, onSortBy }) => (
   <UsersTableStyled numColumns={5}>
     <TableHeader sortedHeader={sortBy.field} sortDir={sortBy.dir} onSelectColumn={onSortBy}>
-      {/* <TableHeader> */}
-      <SortableHeader field="username" ordering={ordering} setOrdering={setOrdering}>
-        Username
-      </SortableHeader>
-      <SortableHeader field="email" ordering={ordering} setOrdering={setOrdering}>
-        Email
-      </SortableHeader>
-      <SortableHeader field="admin" setOrdering={setOrdering}>
-        Admin?
-      </SortableHeader>
-      <SortableHeader field="last_login" ordering={ordering} setOrdering={setOrdering}>
-        Last Login
-      </SortableHeader>
+      <SortableHeader field="username">Username</SortableHeader>
+      <SortableHeader field="email">Email</SortableHeader>
+      <SortableHeader field="admin">Admin?</SortableHeader>
+      <SortableHeader field="last_login">Last Login</SortableHeader>
       <TableCell header>Actions</TableCell>
     </TableHeader>
     <TableBody>

--- a/src/components/pages/UsersPage/UsersTable.js
+++ b/src/components/pages/UsersPage/UsersTable.js
@@ -219,7 +219,7 @@ const UsersTable = ({ users, sortBy, onSortBy }) => (
     <TableHeader sortedHeader={sortBy.field} sortDir={sortBy.dir} onSelectColumn={onSortBy}>
       <SortableHeader field="username">Username</SortableHeader>
       <SortableHeader field="email">Email</SortableHeader>
-      <SortableHeader field="admin">Admin?</SortableHeader>
+      <TableCell header>Admin?</TableCell>
       <SortableHeader field="last_login">Last Login</SortableHeader>
       <TableCell header>Actions</TableCell>
     </TableHeader>

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -100,12 +100,13 @@ export const api = createApi({
       query: () => ({ url: 'token/', method: 'delete' }),
     }),
     users: builder.query({
-      query: ({ params, id }) => {
+      query: ({ queryString, id }) => {
         let url = 'users/';
         if (id) {
           url = `${url}/${id}/`;
         }
-        return { url, method: 'get', params };
+        url = `${url}?${queryString}`;
+        return { url, method: 'get' };
       },
       providesTags: ['User'],
     }),


### PR DESCRIPTION
- Fixed sortable headers on the UsersTable found on UsersPage. 
- Reused existing logic from AgengiesPage to build the URL query parameters and set the sorting order. 
- Adjusted the getUsersQuery in ./service/api.js to append the query parameters to the end of the URL.

Sorting is not yet supported for the Admin column. That will require changes to the back end and will be addressed in a future PR.