### PR TITLE
Update versions of GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,24 +25,19 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-      - uses: actions/setup-node@v3
+          cache: "pip"
+          cache-dependency-path: "requirements/**.txt"
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/**.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+        uses: docker/setup-buildx-action@v3
       - name: Cache Docker build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile') }}
@@ -55,7 +50,7 @@ jobs:
           npm run lint
           npx prettier --check .
       - name: Build Docker Deploy Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           builder: ${{ steps.buildx.outputs.name }}
           load: true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Durham Expunction and Restoration (DEAR)](https://www.deardurham.org)
     - [Running tests with py.test](#running-tests-with-pytest)
     - [Test coverage](#test-coverage)
     - [Sign up for Sentry](#sign-up-for-sentry)
-- [Production testing](#production-testing)
+  - [Production testing](#production-testing)
 
 ## 🚀 Docker Quick Start
 
@@ -228,6 +228,6 @@ To test the production Dockerfile locally, run:
 
 ```sh
 COMPOSE_FILE=docker-compose.deploy.yml docker compose up --build -d django
-# View logs for debugging
+#  View logs for debugging
 COMPOSE_FILE=docker-compose.deploy.yml docker compose logs django -f
 ```


### PR DESCRIPTION
Hopefully squashes warnings during GitHub action builds:

<img width="879" alt="image" src="https://github.com/deardurham/dear-petition/assets/129679/977af226-7efa-4349-8d47-32aeade76af0">
