### PR TITLE
District court offenses were showing up on the superior court petitio…

### DIFF
--- a/dear_petition/petition/types/adult_felonies.py
+++ b/dear_petition/petition/types/adult_felonies.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def get_offense_records(batch, jurisdiction=""):
     qs = OffenseRecord.objects.filter(offense__ciprs_record__batch=batch)
     if jurisdiction:
-        qs = qs.filter(offense__ciprs_record__jurisdiction=jurisdiction)
+        qs = qs.filter(offense__jurisdiction=jurisdiction)
     dob = resolve_dob(qs)
     if not dob:
         return qs  # We can't determine this petition type without the date of birth
@@ -25,9 +25,9 @@ def get_offense_records(batch, jurisdiction=""):
 
 def build_query(dob):
     action = Q(action=pc.CONVICTED)
-    verdict = Q(severity__iexact=pc.SEVERITIES.FELONY)
+    severity = Q(severity__iexact=pc.SEVERITIES.FELONY)
     today = timezone.now().date()
     waiting_period_start_date = today - relativedelta(years=10)
     waiting_period = Q(offense__disposed_on__lt=waiting_period_start_date)
-    query = action & verdict & waiting_period
+    query = action & severity & waiting_period
     return query

--- a/dear_petition/petition/types/adult_misdemeanors.py
+++ b/dear_petition/petition/types/adult_misdemeanors.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def get_offense_records(batch, jurisdiction=""):
     qs = OffenseRecord.objects.filter(offense__ciprs_record__batch=batch)
     if jurisdiction:
-        qs = qs.filter(offense__ciprs_record__jurisdiction=jurisdiction)
+        qs = qs.filter(offense__jurisdiction=jurisdiction)
     dob = resolve_dob(qs)
     if not dob:
         return qs  # We can't determine this petition type without the date of birth
@@ -25,9 +25,9 @@ def get_offense_records(batch, jurisdiction=""):
 
 def build_query(dob):
     action = Q(action=pc.CONVICTED)
-    verdict = Q(severity__iexact=pc.SEVERITIES.MISDEMEANOR)
+    severity = Q(severity__iexact=pc.SEVERITIES.MISDEMEANOR)
     today = timezone.now().date()
     waiting_period_start_date = today - relativedelta(years=5)
     waiting_period = Q(offense__disposed_on__lt=waiting_period_start_date)
-    query = action & verdict & waiting_period
+    query = action & severity & waiting_period
     return query


### PR DESCRIPTION
…ns because the filter condition was using the jurisdiction fo the CIPRS record rather than the jurisdiction of the record. I suspect this is an artifact of the time when we thought a CIPRS record had only one jurisdiction. We now know that it is possible for a CIPRS record to have both in the case of superseding indictments. The convictions petitions should go by the jurisdiction of the offense, rather than the CIPRS record