### PR TITLE
Previously, we went by the jurisction of the containing CIPRS record …

### DIFF
--- a/dear_petition/petition/types/dismissed.py
+++ b/dear_petition/petition/types/dismissed.py
@@ -10,7 +10,7 @@ from dear_petition.petition.constants import (
 def get_offense_records(batch, jurisdiction=""):
     qs = OffenseRecord.objects.filter(offense__ciprs_record__batch=batch)
     if jurisdiction:
-        qs = qs.filter(offense__ciprs_record__jurisdiction=jurisdiction)
+        qs = qs.filter(offense__jurisdiction=jurisdiction)
     qs = qs.filter(build_query()).exclude(severity="INFRACTION")
     return qs.select_related("offense__ciprs_record__batch")
 

--- a/dear_petition/petition/types/main.py
+++ b/dear_petition/petition/types/main.py
@@ -29,11 +29,9 @@ def petition_offense_records(batch, petition_type, jurisdiction=""):
 
 
 def identify_distinct_petitions(offense_records):
-    qs = offense_records.values(
-        "offense__ciprs_record__jurisdiction", "offense__ciprs_record__county"
-    )
+    qs = offense_records.values("offense__jurisdiction", "offense__ciprs_record__county")
     qs = qs.values(
-        jurisdiction=F("offense__ciprs_record__jurisdiction"),
+        jurisdiction=F("offense__jurisdiction"),
         county=F("offense__ciprs_record__county"),
     ).distinct()
     logger.info(f"Distinct petitions: {list(qs.values_list('county', 'jurisdiction'))}")

--- a/dear_petition/petition/types/not_guilty.py
+++ b/dear_petition/petition/types/not_guilty.py
@@ -8,7 +8,7 @@ from dear_petition.petition.types.dismissed import build_query as build_dismisse
 def get_offense_records(batch, jurisdiction=""):
     qs = OffenseRecord.objects.filter(offense__ciprs_record__batch=batch)
     if jurisdiction:
-        qs = qs.filter(offense__ciprs_record__jurisdiction=jurisdiction)
+        qs = qs.filter(offense__jurisdiction=jurisdiction)
     query = build_query()
     qs = qs.filter(query).exclude(severity="INFRACTION")
     return qs.select_related("offense__ciprs_record__batch")

--- a/dear_petition/petition/types/tests/test_dismissed.py
+++ b/dear_petition/petition/types/tests/test_dismissed.py
@@ -68,6 +68,7 @@ def test_offense_records_by_jurisdiction(batch, jurisdiction):
     offense = OffenseFactory(
         disposition_method=constants.CIPRS_DISPOSITION_METHODS_DISMISSED[0],
         ciprs_record=ciprs_record,
+        jurisdiction=jurisdiction,
     )
     offense_record = OffenseRecordFactory(action="CHARGED", offense=offense)
     records = batch.dismissed_offense_records(jurisdiction=jurisdiction)

--- a/dear_petition/petition/types/tests/test_distinct_petitions.py
+++ b/dear_petition/petition/types/tests/test_distinct_petitions.py
@@ -28,7 +28,11 @@ def test_distinct_petition__many(batch):
     for jurisdiction in [constants.DISTRICT_COURT, constants.SUPERIOR_COURT]:
         for county in ["DURHAM", "WAKE"]:
             record = CIPRSRecordFactory(jurisdiction=jurisdiction, county=county, batch=batch)
-            offense = OffenseFactory(disposition_method=method, ciprs_record=record)
+            offense = OffenseFactory(
+                disposition_method=method,
+                ciprs_record=record,
+                jurisdiction=jurisdiction,
+            )
             OffenseRecordFactory(action="CHARGED", offense=offense)
     petition_types = identify_distinct_petitions(batch.dismissed_offense_records())
     assert petition_types.count() == 4

--- a/dear_petition/petition/types/underaged_convictions.py
+++ b/dear_petition/petition/types/underaged_convictions.py
@@ -28,7 +28,7 @@ def get_offense_records(batch, jurisdiction=""):
         )  # We can't determine this petition type without the date of birth
 
     if jurisdiction:
-        qs = qs.filter(offense__ciprs_record__jurisdiction=jurisdiction)
+        qs = qs.filter(offense__jurisdiction=jurisdiction)
 
     query = build_query(dob)
     qs = qs.filter(query).exclude(severity="INFRACTION")


### PR DESCRIPTION
…when determining the jurisdiction of the offenses. However, it is possible for a CIPRS record to contain both district and superior court offenses in cases where the offense has a superseding indictment. We should always go by which section the offense is in (District Court Offense Information vs Superior Court Offense Information) when determining the offense's jurisdiction.