### PR TITLE
Increase timeout for web services

### DIFF
--- a/src/service/axios.js
+++ b/src/service/axios.js
@@ -4,7 +4,7 @@ import { CSRF_COOKIE_NAME, CSRF_HEADER_KEY } from '../constants/authConstants';
 
 const Axios = axios.create({
   baseURL: `/petition/api/`,
-  timeout: 5 * 1000,
+  timeout: 20 * 1000,
   withCredentials: true, // allow setting/passing cookies
   xsrfCookieName: CSRF_COOKIE_NAME,
   xsrfHeaderName: CSRF_HEADER_KEY,


### PR DESCRIPTION
We were seeing timeouts when loading the petition list page for a client who had a large number of petitions