### PR TITLE
Decrease celery concurrency because Heroku says it is using too much …

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -17,5 +17,5 @@ run:
   web: uwsgi --http=0.0.0.0:$PORT --show-config
   worker:
     command:
-      - celery --app=dear_petition worker --beat -l info
+      - celery --app=dear_petition worker --concurrency 2 --beat -l info
     image: web


### PR DESCRIPTION
…memory, causing dyno to crash