### PR TITLE
Updated dev container image from python 3.8 to 3.12

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:0-3.8-bullseye
+FROM mcr.microsoft.com/devcontainers/python:3.12-bullseye
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
Changed microsoft/devcontainers python version from 0-3.8 to 3.12, since python 3.8 was causing installation errors for requirements/local.txt (sphinx and pre-commit failed to install, with error messages indicating version mismatch with python 3.8)