### PR TITLE
Populate DOB on record summary from Petitioner Info

### DIFF
--- a/dear_petition/petition/api/viewsets.py
+++ b/dear_petition/petition/api/viewsets.py
@@ -439,6 +439,9 @@ class BatchViewSet(viewsets.ModelViewSet):
         batch = self.get_object()
         batch.client = client
         batch.save()
+        if not client.dob and batch.dob:
+            client.dob = batch.dob
+            client.save()
         batch.adjust_for_new_client_dob()
         return Response({"batch_id": batch.pk})
 

--- a/dear_petition/petition/export/documents/records_summary.py
+++ b/dear_petition/petition/export/documents/records_summary.py
@@ -31,7 +31,7 @@ def generate_summary(batch):
 
 
 def generate_context(batch, attorney, client):
-    dob = batch.dob
+    dob = client.dob if client.dob else batch.dob
     birthday_18th = "None"
     birthday_22nd = "None"
 


### PR DESCRIPTION
Update to records_summary.py resolves #494 

Additionally this update has a side-effect of preferring the user input DOB from petitioner info when generating record summary, even if a batch DOB exists (in case of pdf uploads). This was discussed at 11/26 meeting as desired way discrepancies between client dob and batch dob should be handled.

We also discussed updating so that petitioner info DOB populates from the batch DOB in cases where user leaves DOB blank in petitioner info user input (see update to api/viewsets.py).