### PR TITLE
Adding warning message for DOB mismatch

### DIFF
--- a/dear_petition/petition/api/serializers.py
+++ b/dear_petition/petition/api/serializers.py
@@ -473,6 +473,7 @@ class BatchDetailSerializer(serializers.ModelSerializer):
             "pk",
             "label",
             "date_uploaded",
+            "dob",
             "user",
             "records",
             "petitions",

--- a/src/components/elements/Input/FormDateInput.jsx
+++ b/src/components/elements/Input/FormDateInput.jsx
@@ -1,8 +1,8 @@
 import { useController } from 'react-hook-form';
 import { AnimatePresence } from 'framer-motion';
-import { InputWrapper, InputStyled, ActualInputStyled, InputErrors } from './Input.styled';
+import { InputWrapper, InputStyled, ActualInputStyled, InputErrors, InputWarnings } from './Input.styled';
 
-const FormDateInput = ({ className, label, errors, inputProps, ...restProps }) => {
+const FormDateInput = ({ className, label, errors, warnings, inputProps, ...restProps }) => {
   const { field, fieldState } = useController(inputProps);
   const { error: inputError } = fieldState;
   const error = inputError ? (
@@ -15,8 +15,8 @@ const FormDateInput = ({ className, label, errors, inputProps, ...restProps }) =
     <InputWrapper className={className}>
       <InputStyled>{label}</InputStyled>
       <ActualInputStyled type="date" {...field} {...restProps} />
-      {error && (
-        <AnimatePresence>
+      <AnimatePresence>
+        {error && (
           <InputErrors
             initial={{ opacity: 0, y: -25 }}
             animate={{ opacity: 1, y: 0 }}
@@ -25,8 +25,20 @@ const FormDateInput = ({ className, label, errors, inputProps, ...restProps }) =
           >
             {error}
           </InputErrors>
-        </AnimatePresence>
-      )}
+        )}
+        {warnings && (
+          <InputWarnings
+            initial={{ opacity: 0, y: -25 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: '50' }}
+            positionTransition
+          >
+            {warnings.map((warningMsg) => (
+              <p key={warningMsg}>{warningMsg}</p>
+            ))}
+          </InputWarnings>
+        )}
+      </AnimatePresence>
     </InputWrapper>
   );
 };

--- a/src/components/elements/Input/Input.jsx
+++ b/src/components/elements/Input/Input.jsx
@@ -1,25 +1,35 @@
 import React from 'react';
-import { InputWrapper, InputStyled, ActualInputStyled, InputErrors } from './Input.styled';
+import { InputWrapper, InputStyled, ActualInputStyled, InputErrors, InputWarnings } from './Input.styled';
 import { AnimatePresence } from 'framer-motion';
 
-function Input({ className, innerClassName, label, errors, register, name, type, ...inputProps }, ref) {
+function Input({ className, innerClassName, label, errors, warnings, register, name, type, ...inputProps }, ref) {
   const registerProps = register && name ? { ...register(name) } : {};
+
+  const errorAnimateProps = {
+    initial: { opacity: 0, y: -25 },
+    animate: { opacity: 1, y: 0 },
+    exit: { opacity: 0, y: '50' },
+    positionTransition: true,
+  };
+
   return (
     <InputWrapper className={className}>
       <InputStyled>{label}</InputStyled>
       <ActualInputStyled className={innerClassName} type={type} {...inputProps} {...registerProps} ref={ref} />
-      {errors && (
-        <AnimatePresence>
-          <InputErrors
-            initial={{ opacity: 0, y: -25 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: '50' }}
-            positionTransition
-          >
+      <AnimatePresence>
+        {errors && (
+          <InputErrors key="input-errors" {...errorAnimateProps}>
             {errors && errors.map((errMsg) => <p key={errMsg}>{errMsg}</p>)}
           </InputErrors>
-        </AnimatePresence>
-      )}
+        )}
+        {warnings && (
+          <InputWarnings key="input-warnings" {...errorAnimateProps}>
+            {warnings.map((warningMsg) => (
+              <p key={warningMsg}>{warningMsg}</p>
+            ))}
+          </InputWarnings>
+        )}
+      </AnimatePresence>
     </InputWrapper>
   );
 }

--- a/src/components/elements/Input/Input.styled.jsx
+++ b/src/components/elements/Input/Input.styled.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colorGrey, colorRed, colorFontPrimary } from '../../../styles/colors';
+import { colorGrey, colorRed, colorFontPrimary, colorWarningOnWhiteBackground } from '../../../styles/colors';
 import { motion } from 'framer-motion';
 import { fontPrimary } from '../../../styles/fonts';
 import { smallerThanTabletLandscape } from '../../../styles/media';
@@ -25,6 +25,17 @@ export const InputErrors = styled(motion.div)`
   margin-top: 0.5rem;
   p {
     color: ${colorRed};
+    @media (${smallerThanTabletLandscape}) {
+      font-size: 1.4rem;
+    }
+    white-space: normal;
+  }
+`;
+
+export const InputWarnings = styled(motion.div)`
+  margin-top: 0.5rem;
+  p {
+    color: ${colorWarningOnWhiteBackground};
     @media (${smallerThanTabletLandscape}) {
       font-size: 1.4rem;
     }

--- a/src/components/pages/GenerationPage/GenerationInput/PetitionerInput.jsx
+++ b/src/components/pages/GenerationPage/GenerationInput/PetitionerInput.jsx
@@ -29,7 +29,7 @@ const TextInput = styled(Input)`
 const dobWarningMsg = `Warning: Date of birth entered does not match CIPRS form pdf.
   Petitioner Information date of birth will be used.`;
 
-export const CreateClientModal = ({ onCreate, handleWarnings }) => {
+export const CreateClientModal = ({ onCreate, handleWarnings, handleDobWarning, warnings }) => {
   const modalElement = useRef();
   const { closeModal } = useModalContext();
   return (
@@ -39,6 +39,8 @@ export const CreateClientModal = ({ onCreate, handleWarnings }) => {
         category="client"
         onSubmitSuccess={(submitData) => onCreate(submitData)}
         handleWarnings={handleWarnings}
+        handleDobWarning={handleDobWarning}
+        warnings={warnings}
       />
     </div>
   );
@@ -89,7 +91,7 @@ export default function PetitionerInput({ petitioner, batchDob, errors, onClearE
   const handleDobWarning = (inputDob) => {
     // this function is split off from handleWarnings so it can also be used
     // when editing existing client dob
-    if (batchDob && inputDob !== batchDob) {
+    if (batchDob && inputDob && inputDob !== batchDob) {
       addWarning('dob', dobWarningMsg);
     } else {
       clearWarning('dob');
@@ -127,13 +129,18 @@ export default function PetitionerInput({ petitioner, batchDob, errors, onClearE
             }
           }}
           handleWarnings={handleWarnings}
+          handleDobWarning={handleDobWarning}
+          warnings={editWarnings}
         />
       </ModalButton>
       {petitioner && (
         <Button
           colorClass="neutral"
           className="h-full border border-gray-700 rounded-md shadow-md font-semibold"
-          onClick={() => setIsEditing(true)}
+          onClick={() => {
+            setIsEditing(true);
+            handleWarnings(petitionerData);
+          }}
         >
           <span>
             <FontAwesomeIcon icon={faPencilAlt} /> Edit

--- a/src/components/pages/GenerationPage/GenerationInput/PetitionerInput.jsx
+++ b/src/components/pages/GenerationPage/GenerationInput/PetitionerInput.jsx
@@ -14,8 +14,6 @@ import {
 import Button, { ModalButton } from '../../../elements/Button';
 import { useModalContext } from '../../../elements/Button/ModalButton';
 import { CreateClient } from '../../../../features/CreateClient';
-import { colorWarningOnWhiteBackground } from '../../../../styles/colors';
-import { smallerThanTabletLandscape } from '../../../../styles/media';
 
 const TextInput = styled(Input)`
   input {
@@ -25,18 +23,6 @@ const TextInput = styled(Input)`
   }
   &:not(:last-child) {
     margin-bottom: 1rem;
-  }
-`;
-
-const WarningMessage = styled.div`
-  margin-top: 0.5rem;
-  margin-bottom: 1rem;
-  p {
-    color: ${colorWarningOnWhiteBackground};
-    @media (${smallerThanTabletLandscape}) {
-      font-size: 1.4rem;
-    }
-    white-space: normal;
   }
 `;
 
@@ -103,7 +89,7 @@ export default function PetitionerInput({ petitioner, batchDob, errors, onClearE
   const handleDobWarning = (inputDob) => {
     // this function is split off from handleWarnings so it can also be used
     // when editing existing client dob
-    if (inputDob !== batchDob) {
+    if (batchDob && inputDob !== batchDob) {
       addWarning('dob', dobWarningMsg);
     } else {
       clearWarning('dob');
@@ -163,6 +149,7 @@ export default function PetitionerInput({ petitioner, batchDob, errors, onClearE
         className="h-full border border-gray-700 rounded-md shadow-md font-semibold"
         onClick={async () => {
           clearAllErrors();
+          handleWarnings(petitionerData);
           try {
             await triggerClientUpdate({
               id: petitioner.pk,
@@ -190,6 +177,7 @@ export default function PetitionerInput({ petitioner, batchDob, errors, onClearE
           setIsEditing(false);
           clearAllErrors();
           setPetitionerData(getPetitionerData(petitioner));
+          handleWarnings(getPetitionerData(petitioner));
         }}
       >
         <span>
@@ -258,15 +246,11 @@ export default function PetitionerInput({ petitioner, batchDob, errors, onClearE
               handleDobWarning(e.target.value);
             }}
             errors={isEditing && editErrors.dob}
+            warnings={isEditing && editWarnings.dob}
             onClearError={onClearError}
             disabled={!isEditing}
             type="date"
           />
-          {editWarnings.dob && (
-            <WarningMessage>
-              <p>{editWarnings.dob}</p>
-            </WarningMessage>
-          )}
           <AddressInput
             address={address}
             setAddress={setPetitionerData}

--- a/src/components/pages/GenerationPage/GenerationPage.jsx
+++ b/src/components/pages/GenerationPage/GenerationPage.jsx
@@ -84,7 +84,7 @@ function GenerationPage() {
     );
   }
 
-  const { attorney, client, label } = data;
+  const { attorney, client, dob, label } = data;
 
   const validateInput = () => {
     let hasErrors = false;
@@ -173,7 +173,7 @@ function GenerationPage() {
           />
         </InputSection>
         <InputSection label="Petitioner Information">
-          <PetitionerInput petitioner={client} errors={formErrors} onClearError={clearError} />
+          <PetitionerInput petitioner={client} batchDob={dob} errors={formErrors} onClearError={clearError} />
         </InputSection>
         <InputSection label="Documents">
           <div className="flex gap-4">

--- a/src/features/CreateClient.jsx
+++ b/src/features/CreateClient.jsx
@@ -14,6 +14,7 @@ export const CreateClient = ({
   onSubmitSuccess,
   submitAndKeepOpenTitle = '',
   submitAndCloseTitle = 'Submit',
+  handleWarnings,
 }) => {
   const [triggerCreate] = useCreateClientMutation();
   const { control, handleSubmit, reset } = useForm({
@@ -46,6 +47,7 @@ export const CreateClient = ({
   };
   const onSubmitAndClose = async (data) => {
     await onSubmit(data);
+    handleWarnings(data);
     onClose();
   };
   return (

--- a/src/features/CreateClient.jsx
+++ b/src/features/CreateClient.jsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { useCreateClientMutation } from '../service/api';
 import US_STATES from '../constants/US_STATES';
@@ -15,6 +15,8 @@ export const CreateClient = ({
   submitAndKeepOpenTitle = '',
   submitAndCloseTitle = 'Submit',
   handleWarnings,
+  handleDobWarning,
+  warnings,
 }) => {
   const [triggerCreate] = useCreateClientMutation();
   const { control, handleSubmit, reset } = useForm({
@@ -50,6 +52,7 @@ export const CreateClient = ({
     handleWarnings(data);
     onClose();
   };
+  const dobFieldValue = useWatch({ control, name: 'dob' });
   return (
     <div className="flex flex-col gap-8">
       <h3>{'Add New Client'}</h3>
@@ -69,6 +72,10 @@ export const CreateClient = ({
             name: 'dob',
             rules: { required: false },
           }}
+          onBlur={() => {
+            handleDobWarning(dobFieldValue);
+          }}
+          warnings={warnings.dob}
         />
         <FormTextArea
           label="Address"

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -8,6 +8,7 @@ export const colorGreen = '#89af5b';
 export const colorRed = '#b04846';
 export const colorBlue = '#4082c3';
 export const colorYellow = '#d1d156';
+export const colorOrange = '#fc9a23';
 
 /* COLORS */
 export const colorPrimary = '#3d8f9d';
@@ -18,6 +19,7 @@ export const colorFontPrimary = colorBlack;
 export const colorSuccess = colorBlue;
 export const colorCaution = colorRed;
 export const colorWarning = colorYellow;
+export const colorWarningOnWhiteBackground = colorOrange;
 
 /**
  * greyScale


### PR DESCRIPTION
This update adds a warning message for the case where a user inputs dob on the petitioner info that does not match the existing dob in the batch (as would happen when DOB is pulled from an uploaded CIPRS record form which had incorrect DOB).

The warning message does not show in the case where there is no batch dob (e.g. with portal imports).

Note that the warning message is only displayed during client creation and while editing, and the warning is hidden once changes are saved.

Resolves issue #523 