### PR TITLE
updated so that user entered dob overrides record.dob

### DIFF
--- a/dear_petition/petition/export/forms.py
+++ b/dear_petition/petition/export/forms.py
@@ -91,7 +91,9 @@ class AOCFormCR287(PetitionForm):
             self.data["NamePetitioner"] = record.label
             self.data["Race"] = record.race
             self.data["Sex"] = record.sex
-            self.data["DOB"] = self.format_date(record.dob)
+            ## updated so user input client.dob overrides record.dob
+            dob = client.dob if client.dob else record.dob
+            self.data["DOB"] = self.format_date(dob)
 
     def map_attorney(self):
         attorney = self.extra["attorney"]
@@ -274,7 +276,9 @@ class AOCFormCR297(AOCFormCR287):
             record = offense_record.offense.ciprs_record
             self.data["Race"] = record.race
             self.data["Sex"] = record.sex
-            self.data["DOB"] = self.format_date(record.dob)
+            ## updated so user input client.dob overrides record.dob
+            dob = client.dob if client.dob else record.dob
+            self.data["DOB"] = self.format_date(dob)
 
     def map_additional_forms(self):
         if self.petition.offense_records.filter(petitionoffenserecord__active=True).count() > 1:

--- a/dear_petition/petition/export/tests/test_cr287.py
+++ b/dear_petition/petition/export/tests/test_cr287.py
@@ -78,6 +78,15 @@ def test_map_petitioner__dob(form, record2, client, offense_record1):
     assert form.data["DOB"] == utils.format_petition_date(client.dob)
 
 
+def test_map_petitioner__dob_client_dob_missing(form, record2, client, offense_record1):
+    ## if client.dob is missing then dob should come from record instead
+    client.dob = None
+    record2.dob = dt.date(2000, 1, 1)
+    record2.save()
+    form.map_petitioner()
+    assert form.data["DOB"] == utils.format_petition_date(record2.dob)
+
+
 def test_map_petitioner__address(form):
     client = ClientFactory(address1="123 Test St", address2="Apt 404")
     form.extra["client"] = client

--- a/dear_petition/petition/export/tests/test_cr287.py
+++ b/dear_petition/petition/export/tests/test_cr287.py
@@ -69,11 +69,13 @@ def test_map_petitioner__sex(form, record2, offense_record1):
     assert form.data["Sex"] == record2.sex
 
 
-def test_map_petitioner__dob(form, record2, offense_record1):
+def test_map_petitioner__dob(form, record2, client, offense_record1):
     record2.dob = dt.date(2000, 1, 1)
     record2.save()
     form.map_petitioner()
-    assert form.data["DOB"] == utils.format_petition_date(record2.dob)
+    ## updated this to check that form.data["DOB"] comes from client.dob
+    ## since user input dob should override record.dob
+    assert form.data["DOB"] == utils.format_petition_date(client.dob)
 
 
 def test_map_petitioner__address(form):


### PR DESCRIPTION
Updated so that user entered dob overrides record.dob when generating petitions.

Resolves issue #530 