### PR TITLE
Refactoring dob warnings to encapsulate form warning logic in a custom hook

### DIFF
--- a/src/components/pages/GenerationPage/GenerationInput/PetitionerInput.jsx
+++ b/src/components/pages/GenerationPage/GenerationInput/PetitionerInput.jsx
@@ -75,14 +75,12 @@ export default function PetitionerInput({ petitioner, batchDob, errors, onClearE
   const clearAllErrors = () => setEditErrors({});
 
   const expectedValues = { dob: batchDob };
-  const { warnings, handleWarning, handleAllWarnings } = useFormWarnings(
-    { dob: [(dob) => expectedValues.dob && dob != expectedValues.dob] },
-    {
-      dob: [
-        `Warning: Date of birth entered does not match CIPRS form pdf.
-                Petitioner Information date of birth will be used.`,
-      ],
-    },
+  const { warnings, handleWarning, handleAllWarnings, addWarningType } = useFormWarnings();
+  addWarningType(
+    'dob',
+    (dob) => expectedValues.dob && dob != expectedValues.dob,
+    `Warning: Date of birth entered does not match CIPRS form pdf.
+                 Petitioner Information date of birth will be used.`,
   );
 
   const clientErrors = (errors?.client ?? editErrors?.client)?.map((errMsg) => (

--- a/src/features/CreateClient.jsx
+++ b/src/features/CreateClient.jsx
@@ -7,6 +7,7 @@ import FormSelect from '../components/elements/Input/FormSelect';
 import FormDateInput from '../components/elements/Input/FormDateInput';
 import FormTextArea from '../components/elements/Input/FormTextArea';
 import { Button } from '../components/elements/Button';
+import useFormWarnings from '../hooks/useFormWarnings';
 
 export const CreateClient = ({
   onClose,
@@ -14,9 +15,7 @@ export const CreateClient = ({
   onSubmitSuccess,
   submitAndKeepOpenTitle = '',
   submitAndCloseTitle = 'Submit',
-  handleWarnings,
-  handleDobWarning,
-  warnings,
+  expectedValues,
 }) => {
   const [triggerCreate] = useCreateClientMutation();
   const { control, handleSubmit, reset } = useForm({
@@ -49,10 +48,19 @@ export const CreateClient = ({
   };
   const onSubmitAndClose = async (data) => {
     await onSubmit(data);
-    handleWarnings(data);
     onClose();
   };
   const dobFieldValue = useWatch({ control, name: 'dob' });
+  const { warnings, handleWarning } = useFormWarnings(
+    { dob: [(dob) => expectedValues.dob && dob != expectedValues.dob] },
+    {
+      dob: [
+        `Warning: Date of birth entered does not match CIPRS form pdf.
+              Petitioner Information date of birth will be used.`,
+      ],
+    },
+  );
+
   return (
     <div className="flex flex-col gap-8">
       <h3>{'Add New Client'}</h3>
@@ -73,7 +81,7 @@ export const CreateClient = ({
             rules: { required: false },
           }}
           onBlur={() => {
-            handleDobWarning(dobFieldValue);
+            handleWarning('dob', dobFieldValue);
           }}
           warnings={warnings.dob}
         />

--- a/src/features/CreateClient.jsx
+++ b/src/features/CreateClient.jsx
@@ -51,14 +51,12 @@ export const CreateClient = ({
     onClose();
   };
   const dobFieldValue = useWatch({ control, name: 'dob' });
-  const { warnings, handleWarning } = useFormWarnings(
-    { dob: [(dob) => expectedValues.dob && dob != expectedValues.dob] },
-    {
-      dob: [
-        `Warning: Date of birth entered does not match CIPRS form pdf.
-              Petitioner Information date of birth will be used.`,
-      ],
-    },
+  const { warnings, handleWarning, addWarningType } = useFormWarnings();
+  addWarningType(
+    'dob',
+    (dob) => expectedValues.dob && dob != expectedValues.dob,
+    `Warning: Date of birth entered does not match CIPRS form pdf.
+               Petitioner Information date of birth will be used.`,
   );
 
   return (

--- a/src/hooks/useFormWarnings.js
+++ b/src/hooks/useFormWarnings.js
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+const useFormWarnings = (warningCheckers, warningMsgs) => {
+  /**
+   * This is a hook to create state to track warnings state for forms, and returns the warnings
+   * state as well as handlers for updating all warnings and updating a single field's warning.
+   *
+   * @param {object} warningCheckers - object that maps array of warning checker functions for each field
+   * e.g. {'dob': [fn, fn2], 'otherField': [otherFieldFn]}, where fn is a function that
+   * returns true if a warning should be displayed, false otherwise (e.g. fn = (dob) => { dob != expectedDob })
+   * @param {object} warningMsgs - object that maps array of warning message strings for each field
+   * e.g. { 'dob': ['Warning: DOB does not match expected value.', 'other type of warning message for this field'],
+   *                  'otherField': ['Warning message for other field.']}
+   * Note that array indices must match between corresponding warningChecker and warningMsg
+   * @returns {object} object containing:
+   * reference to the warnings state, a single-field warning handler, and an all-fields warning handler
+   */
+
+  const [warnings, setWarnings] = useState({});
+  // note: reworked addWarning so that it can store more than one non-duplicate warning per field
+  const addWarning = (key, warningMsg) => {
+    // only add the warning if not a duplicate
+    if (!warnings[key] || !warnings[key].includes(warningMsg)) {
+      setWarnings((prev) => ({ ...prev, [key]: [...(prev[key] ?? []), warningMsg] }));
+    }
+  };
+  // note: reworked clearWarning so that it can remove warningMsg from a list of warningMsgs for the field
+  const clearWarning = (key, warningMsg) => {
+    if (warnings[key] && warnings[key].includes(warningMsg)) {
+      setWarnings((prev) => ({ ...prev, [key]: prev[key].filter((msg) => msg != warningMsg) }));
+    }
+  };
+
+  const handleWarning = (fieldName, value) => {
+    /*
+        Use this function to check if a certain field needs warnings displayed based on its current value.
+        Updates the warnings state to true for that field if warning should be displayed, false otherwise.
+        */
+    const warningCheckersForField = warningCheckers[fieldName];
+    const warningMsgsForField = warningMsgs[fieldName];
+
+    // since there could potentially be more than one possible warning type per field,
+    // loop through the list of warningCheckers and warningMsgs and check for each warning type
+    for (let i = 0; i < warningCheckersForField.length; i++) {
+      const checkForWarning = warningCheckersForField[i];
+      const warningMsg = warningMsgsForField[i];
+
+      if (checkForWarning(value)) {
+        addWarning(fieldName, warningMsg);
+      } else {
+        clearWarning(fieldName, warningMsg);
+      }
+    }
+  };
+
+  const handleAllWarnings = (values) => {
+    /*
+        Use this function to check all fields of a form to see if any warnings need to be displayed based on
+        forms current values. Updates the warnings state for all fields using the 
+        handleWarning(fieldName, value) function.
+        */
+    Object.keys(warningCheckers).forEach((fieldName) => {
+      handleWarning(fieldName, values[fieldName]);
+    });
+  };
+
+  return { warnings, handleWarning, handleAllWarnings };
+};
+
+export default useFormWarnings;

--- a/src/hooks/useFormWarnings.js
+++ b/src/hooks/useFormWarnings.js
@@ -1,70 +1,105 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
-const useFormWarnings = (warningCheckers, warningMsgs) => {
-  /**
-   * This is a hook to create state to track warnings state for forms, and returns the warnings
-   * state as well as handlers for updating all warnings and updating a single field's warning.
-   *
-   * @param {object} warningCheckers - object that maps array of warning checker functions for each field
-   * e.g. {'dob': [fn, fn2], 'otherField': [otherFieldFn]}, where fn is a function that
-   * returns true if a warning should be displayed, false otherwise (e.g. fn = (dob) => { dob != expectedDob })
-   * @param {object} warningMsgs - object that maps array of warning message strings for each field
-   * e.g. { 'dob': ['Warning: DOB does not match expected value.', 'other type of warning message for this field'],
-   *                  'otherField': ['Warning message for other field.']}
-   * Note that array indices must match between corresponding warningChecker and warningMsg
-   * @returns {object} object containing:
-   * reference to the warnings state, a single-field warning handler, and an all-fields warning handler
-   */
-
+/**
+ * Hook which creates state to track warning status for forms, and returns the warnings
+ * state as well as a handler for updating a single field's warning, a handler for updating warnings for all fields,
+ * and a function for registering new warning types.
+ *
+ * Initialize by getting warnings state and handlers from useFormWarnings(), then addWarningType() for each warning needed.
+ *
+ * Then use handleWarning(dobValue) or handleAllWarnings(formValues) on events
+ * where you want warnings be re-checked, such as field value changes or form submission.
+ *
+ * @returns {{
+ *   warnings: object,
+ *   handleWarning: function(fieldName, value): void,
+ *   handleAllWarnings: function(values): void,
+ *   addWarningType: function(fieldName, condition, warningMsg): void
+ * }}
+ */
+const useFormWarnings = () => {
+  // state for storing current warnings state, which will be returned to the Component calling this hook
   const [warnings, setWarnings] = useState({});
-  // note: reworked addWarning so that it can store more than one non-duplicate warning per field
-  const addWarning = (key, warningMsg) => {
+  // object to store list of specifications for warnings for each field
+  // e.g. {'fieldName': [{'condition': fn, 'warningMsg': 'Warning message here'}, ...]}
+  const warningsSpecificationsByField = useRef({});
+
+  /*
+    Handlers use this function to add a warning to the list of warnings for fieldName
+    */
+  const addWarning = (fieldName, warningMsg) => {
     // only add the warning if not a duplicate
-    if (!warnings[key] || !warnings[key].includes(warningMsg)) {
-      setWarnings((prev) => ({ ...prev, [key]: [...(prev[key] ?? []), warningMsg] }));
-    }
-  };
-  // note: reworked clearWarning so that it can remove warningMsg from a list of warningMsgs for the field
-  const clearWarning = (key, warningMsg) => {
-    if (warnings[key] && warnings[key].includes(warningMsg)) {
-      setWarnings((prev) => ({ ...prev, [key]: prev[key].filter((msg) => msg != warningMsg) }));
+    if (!warnings[fieldName] || !warnings[fieldName].includes(warningMsg)) {
+      setWarnings((prev) => ({ ...prev, [fieldName]: [...(prev[fieldName] ?? []), warningMsg] }));
     }
   };
 
+  /*
+    Handlers use this function to delete a warning from the list of warnings 
+    if it should no longer be displayed
+    */
+  const clearWarning = (fieldName, warningMsg) => {
+    // remove the warning if it is in the list for fieldName, otherwise do nothing
+    if (warnings[fieldName] && warnings[fieldName].includes(warningMsg)) {
+      setWarnings((prev) => ({ ...prev, [fieldName]: prev[fieldName].filter((msg) => msg != warningMsg) }));
+    }
+  };
+
+  /*
+    Use this function to check if a certain field needs warnings displayed based on its current value.
+    Updates the warnings state to true for that field if warning should be displayed, false otherwise.
+    */
   const handleWarning = (fieldName, value) => {
-    /*
-        Use this function to check if a certain field needs warnings displayed based on its current value.
-        Updates the warnings state to true for that field if warning should be displayed, false otherwise.
-        */
-    const warningCheckersForField = warningCheckers[fieldName];
-    const warningMsgsForField = warningMsgs[fieldName];
+    const warningSpecifications = warningsSpecificationsByField.current[fieldName];
 
-    // since there could potentially be more than one possible warning type per field,
-    // loop through the list of warningCheckers and warningMsgs and check for each warning type
-    for (let i = 0; i < warningCheckersForField.length; i++) {
-      const checkForWarning = warningCheckersForField[i];
-      const warningMsg = warningMsgsForField[i];
+    warningSpecifications.forEach((warningSpec) => {
+      const warningMsg = warningSpec.warningMsg;
 
-      if (checkForWarning(value)) {
+      if (warningSpec.condition(value)) {
         addWarning(fieldName, warningMsg);
       } else {
         clearWarning(fieldName, warningMsg);
       }
-    }
+    });
   };
 
+  /*
+    Use this function to check all fields of a form to see if any warnings need to be displayed based on
+    form's current values. Updates the warnings state for all fields using the 
+    handleWarning(fieldName, value) function.
+    */
   const handleAllWarnings = (values) => {
-    /*
-        Use this function to check all fields of a form to see if any warnings need to be displayed based on
-        forms current values. Updates the warnings state for all fields using the 
-        handleWarning(fieldName, value) function.
-        */
-    Object.keys(warningCheckers).forEach((fieldName) => {
+    Object.keys(warningsSpecificationsByField.current).forEach((fieldName) => {
       handleWarning(fieldName, values[fieldName]);
     });
   };
 
-  return { warnings, handleWarning, handleAllWarnings };
+  /**
+   * Register a new type of warning message for the specified field during initialization.
+   * Stores the conditions to check for this field, and the warning message to display if
+   * these conditions are met, so that this info can be used by the handler functions later on.
+   * Note that it is possible for more than one warning type to be associated with a single field.
+   * @param {string} fieldName - field warning will apply to
+   * @param {function} condition - boolean function that returns true if warning should display, false otherwise
+   * @param {string} warningMsg - the warning message associated with this type of warning
+   */
+  const addWarningType = (fieldName, condition, warningMsg) => {
+    const warningSpecification = { condition: condition, warningMsg: warningMsg };
+
+    // if no array for this fieldName yet in the ref, initialize an empty array for it
+    if (!(fieldName in warningsSpecificationsByField.current)) {
+      warningsSpecificationsByField.current[fieldName] = [];
+    }
+
+    const currentWarningSpecs = warningsSpecificationsByField.current[fieldName];
+
+    // add the new warning spec unless a spec with same warningMsg already exists
+    if (!currentWarningSpecs.some((spec) => spec.warningMsg === warningMsg)) {
+      currentWarningSpecs.push(warningSpecification);
+    }
+  };
+
+  return { warnings, handleWarning, handleAllWarnings, addWarningType };
 };
 
 export default useFormWarnings;


### PR DESCRIPTION
Moved logic for dob warnings to a custom hook and made it more general so it could be reused for other fields more easily. I think this greatly simplifies the code needed to use warnings on the Component side, so might be an acceptable solution for issue #529 since there did not appear to be existing extensions to react-hook-form that do this.

Refactoring in this way also resolves issue #534 since the issue no longer occurs when using a custom hook implementation.