### PR TITLE
Fix bookmarklet

### DIFF
--- a/src/components/pages/PageBase.jsx
+++ b/src/components/pages/PageBase.jsx
@@ -93,7 +93,8 @@ function PageBase({ children, className, ...props }) {
               tooltipContent="To install, please click and drag this button to your bookmarks bar"
             >
               <a
-                href={bookmarklet}
+                ref={(node) => node && node.setAttribute('href', bookmarklet)}
+                href
                 className="cursor-grab"
                 onClick={(e) => {
                   e.preventDefault();


### PR DESCRIPTION
React 19 seemed to have disabled javascript in href. This bypasses it using the recommendation by gaeron.

![image](https://github.com/user-attachments/assets/d61f708a-e99d-49dc-8b43-d06c6fa34c4c)
