### PR TITLE
bugfix for map_petitioner overwriting client name

### DIFF
--- a/dear_petition/petition/export/forms.py
+++ b/dear_petition/petition/export/forms.py
@@ -88,7 +88,6 @@ class AOCFormCR287(PetitionForm):
         offense_record = self.get_most_recent_record()
         if offense_record:
             record = offense_record.offense.ciprs_record
-            self.data["NamePetitioner"] = record.label
             self.data["Race"] = record.race
             self.data["Sex"] = record.sex
             ## updated so user input client.dob overrides record.dob


### PR DESCRIPTION
When generating certain petition forms, the map_petitioner function was overwriting the user input client name with a name pulled from an offense record.

See issue #539 .
(Note that I believe this was affecting forms AOC-CR-288 and 293, rather than 287 and 293 as originally stated).