### PR TITLE
Removing heroku cli feature from devcontainer since it is no longer maintained

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/heroku-cli:1": {},
+		// "ghcr.io/devcontainers-contrib/features/heroku-cli:1": {},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "lts"
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
+		// removed heroku-cli from devcontainers-contrib/features since this repo is no longer maintained
+		// if heroku cli is still needed in devcontainer, consider finding an alternative to this
 		// "ghcr.io/devcontainers-contrib/features/heroku-cli:1": {},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "lts"


### PR DESCRIPTION
Removed the heroku cli feature we were previously using from the devcontainer as it is no longer maintained and could pose risk as a supply chain vulnerability.