### PR TITLE
The DispositionEvents endpoint has multiple types of events. Disposit…

### DIFF
--- a/dear_petition/portal/etl/models.py
+++ b/dear_petition/portal/etl/models.py
@@ -66,7 +66,6 @@ class PartyInfo(BaseModel):
 
 class Disposition(BaseModel):
     event_date: Union[dt.date, None]
-    event: str
     charge_number: int
     charge_offense: str
     criminal_disposition: str

--- a/dear_petition/portal/etl/parsers/dispositions.py
+++ b/dear_petition/portal/etl/parsers/dispositions.py
@@ -18,7 +18,8 @@ def parse_dispositions(record_id):
     disposition_data = disposition_request.json()
     dispositions = []
     for event in disposition_data["Events"]:
-        disposition_label = event["CriminalDispositionLabel"]
+        if event["Type"] != "CriminalDispositionEvent":
+            continue
         event = event["Event"]
         date = event["Date"]
         criminal_dispositions = event["CriminalDispositions"]
@@ -29,7 +30,6 @@ def parse_dispositions(record_id):
             dispositions.append(
                 Disposition(
                     event_date=datetime.strptime(date, "%m/%d/%Y").date(),
-                    event=disposition_label,
                     charge_number=charge_offense["ChargeNumber"],
                     charge_offense=charge_offense["ChargeOffenseDescription"],
                     criminal_disposition=criminal_disposition_type["Description"],

--- a/dear_petition/portal/tests/data/dispositions.json
+++ b/dear_petition/portal/tests/data/dispositions.json
@@ -162,8 +162,10 @@
         "AmendReasons": [],
         "Documents": []
       }
-    }
+    },
+    {"Type": "SentenceEvent"},
+    {"Type": "PleaEvent"}
   ],
-  "Count": 1,
+  "Count": 3,
   "Skipped": 0
 }


### PR DESCRIPTION
The DispositionEvents endpoint has multiple types of events. DispositionEvents that contain the offense information is just one kind. There are also sentencing events and plea events. These have a completely different data structure so the parsing code will not work on them. I think it is fine to skip them as we really only want the offense information. Also, I got rid of parsing the CriminalDispositionLabel as I didn't see anywhere that we actually use it.