### PR TITLE
When an attachment is added due to too many agencies, the added form …

### DIFF
--- a/dear_petition/petition/etl/load.py
+++ b/dear_petition/petition/etl/load.py
@@ -158,7 +158,9 @@ def assign_agencies_to_documents(petition):
                 current_document = current_document.following_document
             except pm.PetitionDocument.DoesNotExist:  # Have to create new attachment
                 current_document = pm.PetitionDocument.objects.create(
-                    petition=petition, previous_document=current_document
+                    petition=petition,
+                    previous_document=current_document,
+                    form_type=ATTACHMENT,
                 )
 
         current_document.agencies.clear()

--- a/dear_petition/petition/etl/tests/test_load.py
+++ b/dear_petition/petition/etl/tests/test_load.py
@@ -99,6 +99,8 @@ def test_assign_agencies_to_documents(petition, petition_document):
     # 4th contact should attachment
     petition.agencies.add(contact4)
     petition = assign_agencies_to_documents(petition)
+    form_types = [document.form_type for document in petition.documents.all()]
+    assert set(form_types) == set(("AOC-CR-287", "AOC-CR-285"))
     assert petition.documents.count() == 2
 
 


### PR DESCRIPTION
…didn't have a form_type set on it which made it display an empty row on the UI and not actually generate the form with the petition